### PR TITLE
Fix ctrl-c causing segfault

### DIFF
--- a/src/grb_solve.jl
+++ b/src/grb_solve.jl
@@ -2,7 +2,7 @@
 
 function optimize(model::Model)
     @assert model.ptr_model != C_NULL
-    ret = @grb_ccall(optimize, Cint, (Ptr{Void},), model)
+    ret = @grb_ccall_intercept(model, optimize, Cint, (Ptr{Void},), model)
     if ret != 0
         throw(GurobiError(model.env, ret))
     end


### PR DESCRIPTION
Ref #52. This seems to work fine on Linux, but is patchy on OS X (I just had it work while running an unrelated solve, but most of the time, ctrl-c still causes a segfault). Not sure if you want to merge, but here it is anyway.

@joehuchette Does the CPLEX version have the same OS X problems, or is that just happening here?
