### PR TITLE
Add support for Gurobi Cloud

### DIFF
--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -19,6 +19,24 @@ type Env
         # finalizer(env, free_env)  ## temporary disable: which tends to sometimes caused warnings
         env
     end
+
+    function Env(cloudhost::ASCIIString, cloudpassword::ASCIIString)
+        a = Array(Ptr{Void}, 1)
+        ret = @grb_ccall(loadclientenv, Cint,
+            (Ptr{Ptr{Void}}, Ptr{UInt8}, Ptr{UInt8}, Cint, Ptr{UInt8},
+                Cint, Cdouble),
+            a, "gurobi.log", cloudhost, -1, cloudpassword, 0, -1)
+        if ret != 0
+            if ret == 10009
+                error("Invalid Gurobi license")
+            else
+                error("Failed to create environment (error $ret).")
+            end
+        end
+        env = new(a[1])
+        # finalizer(env, free_env)  ## temporary disable: which tends to sometimes caused warnings
+        env
+    end
 end
 
 Base.unsafe_convert(ty::Type{Ptr{Void}}, env::Env) = env.ptr_env::Ptr{Void}

--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -25,7 +25,7 @@ type Env
         ret = @grb_ccall(loadclientenv, Cint,
             (Ptr{Ptr{Void}}, Ptr{UInt8}, Ptr{UInt8}, Cint, Ptr{UInt8},
                 Cint, Cdouble),
-            a, "gurobi.log", cloudhost, -1, cloudpassword, 0, -1)
+            a, C_NULL, cloudhost, -1, cloudpassword, 0, -1)
         if ret != 0
             if ret == 10009
                 error("Invalid Gurobi license")

--- a/src/grb_env.jl
+++ b/src/grb_env.jl
@@ -18,7 +18,9 @@ type Env
             if ret == 10009
                 error("Invalid Gurobi license")
             elseif ret == 10022
-                error("Problem communicating with the Gurobi Compute Server")
+                error("""Problem communicating with the Gurobi Compute Server
+                      This might be resolved by setting the following environment variable:
+                      export LD_LIBRARY_PATH=\$\{GUROBI_HOME\}/lib""")
             else
                 error("Failed to create environment (error $ret).")
             end

--- a/test/cloud.jl
+++ b/test/cloud.jl
@@ -1,0 +1,13 @@
+using Base.Test
+using Gurobi
+using MathProgBase.SolverInterface
+
+env = Gurobi.Env("csdemo.gurobi.com")
+Gurobi.free_env(env)
+
+@test_throws ErrorException Gurobi.Env("csdemo.gurobi.com", "wrongpassword")
+
+@test_throws ErrorException Gurobi.Env("fakehostdoesnotexist", "wrongpassword")
+
+solver = GurobiSolver(cloudhost="csdemo.gurobi.com")
+LinearQuadraticModel(solver)

--- a/test/cloud.jl
+++ b/test/cloud.jl
@@ -9,5 +9,5 @@ Gurobi.free_env(env)
 
 @test_throws ErrorException Gurobi.Env("fakehostdoesnotexist", "wrongpassword")
 
-solver = GurobiSolver(cloudhost="csdemo.gurobi.com")
-LinearQuadraticModel(solver)
+include(joinpath(Pkg.dir("MathProgBase"),"test","linproginterface.jl"))
+linprogsolvertest(GurobiSolver(cloudhost="csdemo.gurobi.com"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,7 +6,8 @@ tests = ["lp_01a",
          "qp_01",
          "qp_02",
          "qcqp_01",
-         "mathprog"]
+         "mathprog",
+         "cloud"]
 
 for t in tests
     fp = "$(t).jl"


### PR DESCRIPTION
I wanted to use [Gurobi Cloud](https://cloud.gurobi.com/) for a project I was working on, so I added some code to help with this. The main differences to local installations of Gurobi are:
- It uses the C function `GRBloadclientenv` rather than `GRBloadenv`.
- It takes a host name and password (to log in to the cloud server).

This code works, but it's not as neat as it could be and I'm not sure how to structure it (in a Julia-like manner) so that it doesn't repeat itself. Suggestions would be appreciated. Notice in particular how the new `Env(host, password)` constructor in grb_env.jl is a copy-paste of the existing `Env()`, but with one line changed, and ditto for `GurobiMathProgModel()` in GurobiSolverInterface.jl. Normally I'd use OOP techniques to avoid repetition but I wasn't sure how to fit it in with existing code here.

Also if you can think of a way to test it without having an actual Gurobi Cloud server running, that'd be great too. (This is why there aren't any tests.)

As hinted I don't think it's actually in mergeable condition yet, but since I'd started looking at Gurobi Cloud I thought I may as well put it forward to see if it could become something more useful. :smiley:
