### PR TITLE
Implementing GRBgetvars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Manifest.toml
+REQUIRE

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Manifest.toml
 REQUIRE
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-Manifest.toml
-REQUIRE
-.gitignore

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,0 @@
-julia 0.6
-MathProgBase 0.5 0.8
-Compat 0.33
-LinQuadOptInterface 0.6 0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,0 +1,4 @@
+julia 0.6
+MathProgBase 0.5 0.8
+Compat 0.33
+LinQuadOptInterface 0.6 0.7

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -42,7 +42,7 @@ lowerbounds, upperbounds, objcoeffs, set_objcoeffs!,
 GRB_CONTINUOUS, GRB_BINARY, GRB_INTEGER,
 add_var!, add_vars!, add_cvar!, add_cvars!,
 add_bvar!, add_bvars!, add_ivar!, add_ivars!,
-del_vars!,
+del_vars!, get_vars,
 
 # grb_constrs
 add_constr!, add_constrs!, add_constrs_t!,

--- a/src/grb_constrs.jl
+++ b/src/grb_constrs.jl
@@ -208,7 +208,7 @@ function get_constrs(model::Model, start::Integer, len::Integer)
     V = Array{Float64}(undef, nnz)
     for i in 1:length(cbeg)-1
         for j in (cbeg[i]+1):cbeg[i+1]
-            I[j] = i
+            I[j] = i + start - 1
             J[j] = cind[j]+1
             V[j] = cval[j]
         end

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -178,15 +178,10 @@ function get_vars(model::Model, start::Integer, len::Integer)
         throw(GurobiError(model.env, ret))
     end
 
-    for i in 1:size(vbeg, 1)
-        vbeg[i] += 1
-    end
-
-    for i in 1:size(vind, 1)
-        vind[i] += 1
-    end
-
+    vbeg[i] += 1
+    vind[i] .+= 1
     push!(vbeg, nnz)
+
     I = Array{Int64}(undef, nnz)
     J = Array{Int64}(undef, nnz)
     V = Array{Float64}(undef, nnz)
@@ -198,7 +193,6 @@ function get_vars(model::Model, start::Integer, len::Integer)
         end
     end
 
-    pop!(vbeg)
-
     return SparseArrays.sparse(I, J, V, m, n)
+
 end

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -148,7 +148,7 @@ function get_vars(model::Model, start::Integer, len::Integer)
     # INPUT VALIDATION
     #-----------------
     @assert start > 0               "Indexing in Julia starts from 1."
-    @assert start + len <= n        string("Index out of bounds: There are only ", n, " variables attached to this model.")
+    @assert start + len - 1 <= n    string("Index out of bounds: There are only ", n, " variables attached to this model.")
     @assert len > 0                 "At least one variable must be selected; len > 0."
 
     # FUNCTION CALLS

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -148,9 +148,8 @@ function get_vars(model::Model, start::Integer, len::Integer)
     # INPUT VALIDATION
     #-----------------
     @assert start > 0               "Indexing in Julia starts from 1."
-    @assert start <= n              string("Index out of bounds: There are only ", n, " variables attached to this model.")
+    @assert start + len <= n        string("Index out of bounds: There are only ", n, " variables attached to this model.")
     @assert len > 0                 "At least one variable must be selected; len > 0."
-    @assert start * len <= m * n    "Maximal amount of possible non-zero elements surpassed."
 
     # FUNCTION CALLS
     #---------------

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -136,23 +136,14 @@ function del_vars!(model::Model, idx::Vector{Cint})
 end
 
 function get_vars(model::Model, start::Integer, len::Integer)
-# http://www.gurobi.com/documentation/8.1/refman/c_grbgetvars.html
 
-    # NR_CONTRAINTS
-    #--------------
     m = num_constrs(model)
-    # NR_VARIABLES
-    #-------------
     n = num_vars(model)
 
-    # INPUT VALIDATION
-    #-----------------
     @assert start > 0               "Indexing in Julia starts from 1."
     @assert start + len - 1 <= n    string("Index out of bounds: There are only ", n, " variables attached to this model.")
     @assert len > 0                 "At least one variable must be selected; len > 0."
 
-    # FUNCTION CALLS
-    #---------------
     numnzP = Ref{Cint}()
     vbeg = Array{Cint}(undef, len)
 
@@ -187,8 +178,6 @@ function get_vars(model::Model, start::Integer, len::Integer)
         throw(GurobiError(model.env, ret))
     end
 
-    # ADJUSTING INDICES TO JULIA'S INDEXING.
-    #---------------------------------------
     for i in 1:size(vbeg, 1)
         vbeg[i] += 1
     end
@@ -197,8 +186,6 @@ function get_vars(model::Model, start::Integer, len::Integer)
         vind[i] += 1
     end
 
-    # SPARSE ARRAY
-    #-------------
     push!(vbeg, nnz)
     I = Array{Int64}(undef, nnz)
     J = Array{Int64}(undef, nnz)
@@ -213,6 +200,5 @@ function get_vars(model::Model, start::Integer, len::Integer)
 
     pop!(vbeg)
 
-    # return vbeg, vind, vval
     return SparseArrays.sparse(I, J, V, m, n)
 end

--- a/src/grb_vars.jl
+++ b/src/grb_vars.jl
@@ -178,8 +178,8 @@ function get_vars(model::Model, start::Integer, len::Integer)
         throw(GurobiError(model.env, ret))
     end
 
-    vbeg[i] += 1
-    vind[i] .+= 1
+    vbeg .+= 1
+    vind .+= 1
     push!(vbeg, nnz)
 
     I = Array{Int64}(undef, nnz)

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -7,25 +7,26 @@ using Gurobi, Test
 
     simple_model = Gurobi.Model(simple_model_env, "simple_mip", :maximize)
 
-    add_ivar!(simple_model, 0., 0, Inf)  # p1
-    add_ivar!(simple_model, 0., 0, Inf)  # p2
-    add_ivar!(simple_model, 0., 0, Inf)  # p3
-    add_cvar!(simple_model, 1., 0., Inf) # z
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
+    add_cvar!(simple_model, 1. , 0.0, Inf) # z
+
     update_model!(simple_model)
 
-    add_constr!(simple_model, [3., 5., 4., -1.], '<', 0.)
-    add_constr!(simple_model, [0.5, 2., 1., 0.], '<', 6.)
-    add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.)
+    add_constr!(simple_model, [3., 5., 4., -1.],  '<', 0.0)
+    add_constr!(simple_model, [0.5, 2., 1., 0.0], '<', 6. )
+    add_constr!(simple_model, [3., 5., 4., -1.],  '>', 0.0)
 
     update_model!(simple_model)
 
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 1]...] == [3., 0.5, 3.]
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 2]...] == [5., 2., 5.]
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 3]...] == [4., 1., 4.]
-    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 4]...] == [-1., 0., -1.]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 4]...] == [-1., 0.0, -1.]
 
     @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[1, :]...] == [3., 5., 4., -1.]
-    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[2, :]...] == [0.5, 2., 1., 0.]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[2, :]...] == [0.5, 2., 1., 0.0]
     @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[3, :]...] == [3., 5., 4., -1.]
 
     @test [Gurobi.get_constrs(simple_model, 2, 2)[2, :]...][2] == [Gurobi.get_vars(simple_model, 2, 2)[:, 2]...][2]

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -17,13 +17,8 @@ using Gurobi, Test
     add_constr!(simple_model, [0.5, 2., 1., 0.], '<', 6.)
     add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.)
 
-    setparam!(simple_model, "Heuristics", 0.0)
-    setparam!(simple_model, "Presolve", 0)
-
     update_model!(simple_model)
 
-    optimize(simple_model)
-    print(Gurobi.get_constrs(simple_model, 2, 2)[3, :][4])
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 1]...] == [3., 0.5, 3.]
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 2]...] == [5., 2., 5.]
     @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 3]...] == [4., 1., 4.]

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -31,4 +31,5 @@ using Gurobi, Test
     @test [Gurobi.get_constrs(simple_model, 2, 2)[2, :]...][2] == [Gurobi.get_vars(simple_model, 2, 2)[:, 2]...][2]
     @test Gurobi.get_constrs(simple_model, 2, 2)[3, :][4] == Gurobi.get_vars(simple_model, 3, 2)[:, 4][3]
     @test Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model)) == Gurobi.get_vars(simple_model, 1, num_vars(simple_model))
+
 end

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -10,24 +10,24 @@ using Gurobi, Test
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
-    add_cvar!(simple_model, 1. , 0.0, Inf) # z
+    add_cvar!(simple_model, 1.0, 0.0, Inf) # z
 
     update_model!(simple_model)
 
-    add_constr!(simple_model, [3., 5., 4., -1.],  '<', 0.0)
-    add_constr!(simple_model, [0.5, 2., 1., 0.0], '<', 6. )
-    add_constr!(simple_model, [3., 5., 4., -1.],  '>', 0.0)
+    add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '<', 0.0)
+    add_constr!(simple_model, [0.5, 2.0, 1.0,  0.0], '<', 6.0)
+    add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '>', 0.0)
 
     update_model!(simple_model)
 
-    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 1]...] == [3., 0.5, 3.]
-    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 2]...] == [5., 2., 5.]
-    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 3]...] == [4., 1., 4.]
-    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 4]...] == [-1., 0.0, -1.]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 1]...] == [ 3.0, 0.5,  3.0]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 2]...] == [ 5.0, 2.0,  5.0]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 3]...] == [ 4.0, 1.0,  4.0]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 4]...] == [-1.0, 0.0, -1.0]
 
-    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[1, :]...] == [3., 5., 4., -1.]
-    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[2, :]...] == [0.5, 2., 1., 0.0]
-    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[3, :]...] == [3., 5., 4., -1.]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[1, :]...] == [3.0, 5.0, 4.0, -1.0]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[2, :]...] == [0.5, 2.0, 1.0,  0.0]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[3, :]...] == [3.0, 5.0, 4.0, -1.0]
 
     @test [Gurobi.get_constrs(simple_model, 2, 2)[2, :]...][2] == [Gurobi.get_vars(simple_model, 2, 2)[:, 2]...][2]
     @test Gurobi.get_constrs(simple_model, 2, 2)[3, :][4] == Gurobi.get_vars(simple_model, 3, 2)[:, 4][3]

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -1,3 +1,15 @@
+# Test MIP
+#
+#   maximize z
+#
+#   s.t.  3 p1 + 5 p2 + 4 p3 - z = 0
+#         0.5 p1 + 2 p2 + 1 p3 <= 6
+#
+#         p1 is integer: 0 <= p1
+#         p1 is integer: 0 <= p2
+#         p1 is integer: 0 <= p3
+#         z is binary
+
 using Gurobi, Test
 
 @testset "constr_matrix" begin
@@ -10,7 +22,7 @@ using Gurobi, Test
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
-    add_cvar!(simple_model, 1.0, 0.0, Inf) # z
+    add_cvar!(simple_model, 1.0, 0.0, Inf)  # z
 
     update_model!(simple_model)
 

--- a/test/C/test_constr_matrix.jl
+++ b/test/C/test_constr_matrix.jl
@@ -1,0 +1,39 @@
+using Gurobi, Test
+
+@testset "constr_matrix" begin
+
+    simple_model_env = Gurobi.Env()
+    setparam!(simple_model_env, "OutputFlag", 0)
+
+    simple_model = Gurobi.Model(simple_model_env, "simple_mip", :maximize)
+
+    add_ivar!(simple_model, 0., 0, Inf)  # p1
+    add_ivar!(simple_model, 0., 0, Inf)  # p2
+    add_ivar!(simple_model, 0., 0, Inf)  # p3
+    add_cvar!(simple_model, 1., 0., Inf) # z
+    update_model!(simple_model)
+
+    add_constr!(simple_model, [3., 5., 4., -1.], '<', 0.)
+    add_constr!(simple_model, [0.5, 2., 1., 0.], '<', 6.)
+    add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.)
+
+    setparam!(simple_model, "Heuristics", 0.0)
+    setparam!(simple_model, "Presolve", 0)
+
+    update_model!(simple_model)
+
+    optimize(simple_model)
+    print(Gurobi.get_constrs(simple_model, 2, 2)[3, :][4])
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 1]...] == [3., 0.5, 3.]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 2]...] == [5., 2., 5.]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 3]...] == [4., 1., 4.]
+    @test [Gurobi.get_vars(simple_model, 1, num_vars(simple_model))[:, 4]...] == [-1., 0., -1.]
+
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[1, :]...] == [3., 5., 4., -1.]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[2, :]...] == [0.5, 2., 1., 0.]
+    @test [Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model))[3, :]...] == [3., 5., 4., -1.]
+
+    @test [Gurobi.get_constrs(simple_model, 2, 2)[2, :]...][2] == [Gurobi.get_vars(simple_model, 2, 2)[:, 2]...][2]
+    @test Gurobi.get_constrs(simple_model, 2, 2)[3, :][4] == Gurobi.get_vars(simple_model, 3, 2)[:, 4][3]
+    @test Gurobi.get_constrs(simple_model, 1, num_constrs(simple_model)) == Gurobi.get_vars(simple_model, 1, num_vars(simple_model))
+end

--- a/test/C/test_read.jl
+++ b/test/C/test_read.jl
@@ -28,13 +28,12 @@ using Gurobi, Test
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
-    add_cvar!(simple_model, 1.,  0.0, Inf) # z
+    add_cvar!(simple_model, 1.0, 0.0, Inf) # z
     update_model!(simple_model)
 
-    add_constr!(simple_model, [3., 5., 4., -1.], '<', 0.0)
-    add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.0)
-
-    add_constr!(simple_model, [0.5, 2., 1., 0.0], '<', 6.)
+    add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '<', 0.0)
+    add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '>', 0.0)
+    add_constr!(simple_model, [0.5, 2.0, 1.0,  0.0], '<', 6.0)
 
     setparam!(simple_model, "Heuristics", 0.0)
     setparam!(simple_model, "Presolve", 0)

--- a/test/C/test_read.jl
+++ b/test/C/test_read.jl
@@ -28,7 +28,7 @@ using Gurobi, Test
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
-    add_cvar!(simple_model, 1.0, 0.0, Inf) # z
+    add_cvar!(simple_model, 1.0, 0.0, Inf)  # z
     update_model!(simple_model)
 
     add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '<', 0.0)

--- a/test/C/test_read.jl
+++ b/test/C/test_read.jl
@@ -29,6 +29,7 @@ using Gurobi, Test
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
     add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
     add_cvar!(simple_model, 1.0, 0.0, Inf)  # z
+
     update_model!(simple_model)
 
     add_constr!(simple_model, [3.0, 5.0, 4.0, -1.0], '<', 0.0)

--- a/test/C/test_read.jl
+++ b/test/C/test_read.jl
@@ -25,16 +25,16 @@ using Gurobi, Test
 
     simple_model = Gurobi.Model(simple_model_env, "simple_mip", :maximize)
 
-    add_ivar!(simple_model, 0., 0, Inf)  # p1
-    add_ivar!(simple_model, 0., 0, Inf)  # p2
-    add_ivar!(simple_model, 0., 0, Inf)  # p3
-    add_cvar!(simple_model, 1., 0., Inf) # z
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p1
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p2
+    add_ivar!(simple_model, 0.0, 0.0, Inf)  # p3
+    add_cvar!(simple_model, 1.,  0.0, Inf) # z
     update_model!(simple_model)
 
-    add_constr!(simple_model, [3., 5., 4., -1.], '<', 0.)
-    add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.)
+    add_constr!(simple_model, [3., 5., 4., -1.], '<', 0.0)
+    add_constr!(simple_model, [3., 5., 4., -1.], '>', 0.0)
 
-    add_constr!(simple_model, [0.5, 2., 1., 0.], '<', 6.)
+    add_constr!(simple_model, [0.5, 2., 1., 0.0], '<', 6.)
 
     setparam!(simple_model, "Heuristics", 0.0)
     setparam!(simple_model, "Presolve", 0)


### PR DESCRIPTION
Hi,

I would like to include the function get_vars() (GRBgetvars).
It is similar to the already implemented function get_constrs(), but returns non-zero elements in a Gurobi.Model's constraint matrix based on variables.

---

While testing, I saw that get_constrs() produces inconsistent output regarding indices. The SparseArray it returns always is of size m (constraints) * n (variables). Say, a model has 4 constraints and 4 variables attached. 
If I want to get constraints 3-4, it will return a SparseArray (4 x 4) with those constraints at index [1, :] and [2,:] respectively.
If I use it to return all constraints (1-4), these previous constraints will be positioned at index [3, :] and [4,:].

The function get_constrs() always returns the constraints at their correct index if this little adjustment is made ...

**All tests pass.**

![image](https://user-images.githubusercontent.com/37851720/60178982-4f1ca500-9825-11e9-9fc2-cfa4228f2ba0.png)

![image](https://user-images.githubusercontent.com/37851720/60178936-3a401180-9825-11e9-9950-02fe616d46ef.png)


Best,

Anton