### PR TITLE
Catch [CTRL+C] and gracefully exit

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2303,27 +2303,59 @@ function MOI.optimize!(model::Optimizer)
     if _check_moi_callback_validity(model)
         MOI.set(model, CallbackFunction(), _default_moi_callback(model))
         model.has_generic_callback = false
+    else
+        # TODO(odow): From the docstring of disable_sigint, "External functions
+        # that do not call julia code or julia runtime automatically disable
+        # sigint during their execution." We don't want this though! We want to
+        # be able to SIGINT Gurobi, and then catch it as an interrupt. As a
+        # temporary hack, set a null callback.
+        MOI.set(model, CallbackFunction(), (x, y) -> nothing)
     end
 
     # Catch [CTRL+C], even when Julia is run from a script not in interactive
     # mode. If `true`, then a script would call `atexit` without throwing the
     # `InterruptException`. `false` is the default in interactive mode.
+    #
+    # TODO(odow): Julia 1.5 exposes `Base.exit_on_sigint(::Bool)`.
     ccall(:jl_exit_on_sigint, Cvoid, (Cint,), false)
     model.interrupted = false
     ret = try
         GRBoptimize(model)
     catch ex
-        # Catch the case where the interrupt was thrown from a callback. Since
-        # the callback will not have exited successfully, the callback state
-        # won't have been reset to _CB_NONE yet.
-        model.callback_state = _CB_NONE
-        if !(ex isa InterruptException)
-            rethrow(ex)
+        # Disable sigint here, because we don't want the user to interrupt our
+        # handle of an interrupt!
+        disable_sigint() do
+            if !(ex isa InterruptException)
+                rethrow(ex)
+            end
+            model.interrupted = true
+            # ==================================================================
+            # It wasn't obvious how to gracefully handle this interrupt, so
+            # @odow talked to Gurobi support. They suggest the following:
+            #
+            # Calling GRBterminate(model) will set a flag in the model to
+            # terminate the optimization as soon as possible. Since this will
+            # not immediately stop the process, you might need to wait until the
+            # status is not "OPTIMIZATION_IN_PROGRESS" anymore. Otherwise, you
+            # might run into a race-condition, with the solver still running,
+            # which produces the errors you have seen.
+            #
+            # So GRBterminate() is the right way to go, you just need to
+            # implement some waiting loop afterwards, checking the status.
+            GRBterminate(model)
+            valueP = Ref{Cint}(1)
+            while GRBgetintattr(model, "Status", valueP) == GRB_ERROR_OPTIMIZATION_IN_PROGRESS
+                sleep(0.5)
+            end
+            # ==================================================================
         end
-        model.interrupted = true
-        GRBterminate(model)
         Cint(0)
     finally
+        # If the interrupt was thrown from a callback, the callback will not
+        # have exited successfully, and so the callback state won't have been
+        # reset to _CB_NONE yet. Do it here regardless.
+        model.callback_state = _CB_NONE
+        # Reset jl_exit_on_sigint.
         if !isinteractive()
             ccall(:jl_exit_on_sigint, Cvoid, (Cint,), true)
         end

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2303,7 +2303,7 @@ function MOI.optimize!(model::Optimizer)
     if _check_moi_callback_validity(model)
         MOI.set(model, CallbackFunction(), _default_moi_callback(model))
         model.has_generic_callback = false
-    else
+    elseif !model.has_generic_callback
         # TODO(odow): From the docstring of disable_sigint, "External functions
         # that do not call julia code or julia runtime automatically disable
         # sigint during their execution." We don't want this though! We want to

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1020,6 +1020,28 @@ function test_Attributes()
     @test MOI.get(model, MOI.SimplexIterations()) == 0
 end
 
+function test_GRBterminate()
+    model = Gurobi.Optimizer(GUROBI_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variable(model)
+    MOI.set(model, Gurobi.CallbackFunction(), (cb_data, cb_where) -> begin
+        GRBterminate(model)
+    end)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INTERRUPTED
+end
+
+function test_InterruptException()
+    model = Gurobi.Optimizer(GUROBI_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    x = MOI.add_variable(model)
+    MOI.set(model, Gurobi.CallbackFunction(), (cb_data, cb_where) -> begin
+        throw(InterruptException())
+    end)
+    MOI.optimize!(model)
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.INTERRUPTED
+end
+
 end
 
 runtests(TestMOIWrapper)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1021,7 +1021,7 @@ function test_Attributes()
 end
 
 function test_GRBterminate()
-    model = Gurobi.Optimizer(GUROBI_ENV)
+    model = Gurobi.Optimizer(GRB_ENV)
     MOI.set(model, MOI.Silent(), true)
     x = MOI.add_variable(model)
     MOI.set(model, Gurobi.CallbackFunction(), (cb_data, cb_where) -> begin
@@ -1032,7 +1032,7 @@ function test_GRBterminate()
 end
 
 function test_InterruptException()
-    model = Gurobi.Optimizer(GUROBI_ENV)
+    model = Gurobi.Optimizer(GRB_ENV)
     MOI.set(model, MOI.Silent(), true)
     x = MOI.add_variable(model)
     MOI.set(model, Gurobi.CallbackFunction(), (cb_data, cb_where) -> begin


### PR DESCRIPTION
Closes #52
Closes #53

An updated attempt at #52, inspired by #53.

Does anyone watching this repository have access to a Windows machine they could test this on?

Throwing an interrupt from a callback worked, but on Mac, I could not get a script to exit correctly on CTRL+C. I have to hold down CTRL+C to force a SIGINT, and then I get a Gurobi Error 10017, `OPTIMIZATION_IN_PROGRESS`.
```julia
ERROR: Gurobi Error 10017: 
Stacktrace:
 [1] _check_ret at /Users/oscar/.julia/dev/Gurobi/src/MOI_wrapper.jl:266 [inlined]
 [2] _get_intattr(::Gurobi.Optimizer, ::String) at /Users/oscar/.julia/dev/Gurobi/src/MOI_wrapper.jl:2398
 [3] _is_mip at /Users/oscar/.julia/dev/Gurobi/src/MOI_wrapper.jl:2429 [inlined]
 [4] get(::Gurobi.Optimizer, ::MathOptInterface.DualStatus) at /Users/oscar/.julia/dev/Gurobi/src/MOI_wrapper.jl:2436
 [5] optimize!(::Gurobi.Optimizer) at /Users/oscar/.julia/dev/Gurobi/src/MOI_wrapper.jl:2335
 [6] top-level scope at /Users/oscar/.julia/dev/Gurobi/interrupt.jl:17
 [7] include(::Function, ::Module, ::String) at ./Base.jl:380
 [8] include(::Module, ::String) at ./Base.jl:368
 [9] exec_options(::Base.JLOptions) at ./client.jl:296
 [10] _start() at ./client.jl:506
in expression starting at /Users/oscar/.julia/dev/Gurobi/interrupt.jl:17
```

Here is the script I was running:
```Julia
using Gurobi
const MOI = Gurobi.MOI

download(
    "ftp://ftp.numerical.rl.ac.uk/pub/cuter/netlib/QAP12.SIF",
    "QAP12.mps"
)
mps = MOI.FileFormats.MPS.Model()
MOI.read_from_file(mps, "QAP12.mps")
model = Gurobi.Optimizer()
MOI.copy_to(model, mps)
MOI.add_constraint.(
    model,
    MOI.get(model, MOI.ListOfVariableIndices()),
    MOI.Integer(),
);
MOI.optimize!(model)
@show MOI.get(model, MOI.PrimalStatus())
@assert MOI.get(model, MOI.TerminationStatus()) == MOI.INTERRUPTED
```

I'll reach out to Gurobi support. Not sure if this is publicly accessible, but here is the support ticket: https://support.gurobi.com/hc/en-us/requests/12868.