### PR TITLE
Bump for Gurobi v9.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ instructions on [Gurobi's website](http://www.gurobi.com). Then, set the
 the `Pkg.build("Gurobi")`. For example:
 ```julia
 # On Windows, this might be
-ENV["GUROBI_HOME"] = "C:\\Program Files\\gurobi902\\win64"
+ENV["GUROBI_HOME"] = "C:\\Program Files\\gurobi910\\win64"
 # ... or perhaps ...
-ENV["GUROBI_HOME"] = "C:\\gurobi902\\win64"
+ENV["GUROBI_HOME"] = "C:\\gurobi910\\win64"
 import Pkg
 Pkg.add("Gurobi")
 Pkg.build("Gurobi")
 
 # On Mac, this might be
-ENV["GUROBI_HOME"] = "/Library/gurobi902/mac64"
+ENV["GUROBI_HOME"] = "/Library/gurobi910/mac64"
 import Pkg
 Pkg.add("Gurobi")
 Pkg.build("Gurobi")

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -13,7 +13,7 @@ function write_depsfile(path)
 end
 
 const ALIASES = [
-    "gurobi90",
+    "gurobi90", "gurobi91"
 ]
 
 paths_to_try = copy(ALIASES)
@@ -54,19 +54,19 @@ function _print_GUROBI_HOME_help()
     correct location if needed):
     ```
     # On Windows, this might be
-    ENV["GUROBI_HOME"] = "C:\\\\Program Files\\\\gurobi902\\\\win64\\\\"
+    ENV["GUROBI_HOME"] = "C:\\\\Program Files\\\\gurobi910\\\\win64\\\\"
     import Pkg
     Pkg.add("Gurobi")
     Pkg.build("Gurobi")
 
     # On OSX, this might be
-    ENV["GUROBI_HOME"] = "/Library/gurobi902/mac64/"
+    ENV["GUROBI_HOME"] = "/Library/gurobi910/mac64/"
     import Pkg
     Pkg.add("Gurobi")
     Pkg.build("Gurobi")
 
     # On Unix, this might be
-    ENV["GUROBI_HOME"] = "/opt/gurobi902/linux64/"
+    ENV["GUROBI_HOME"] = "/opt/gurobi910/linux64/"
     import Pkg
     Pkg.add("Gurobi")
     Pkg.build("Gurobi")
@@ -128,7 +128,7 @@ function diagnose_gurobi_install()
             # Try to call `gurobi_cl`. This should work if Gurobi is on the
             # system path. If it succeeds, it will print out the version.
             io = IOBuffer()
-            run(pipeline(`gurobi_cl --version`; stdout = io))
+            run(pipeline(`gurobi_cl --version`; stdout=io))
             seekstart(io)
             println("""
             We couldn't find the `GUROBI_HOME` environment variable, but we

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -17,7 +17,7 @@ include("gen/libgrb_common.jl")
 include("gen/libgrb_api.jl")
 
 const _GUROBI_VERSION = if libgurobi == "julia_registryci_automerge"
-    VersionNumber(9, 0, 0)
+    VersionNumber(9, 1, 0)
 else
     let
         majorP, minorP, technicalP = Ref{Cint}(), Ref{Cint}(), Ref{Cint}()
@@ -26,7 +26,7 @@ else
     end
 end
 
-if !(v"9.0.0" <= _GUROBI_VERSION < v"9.1")
+if !(v"9.0.0" <= _GUROBI_VERSION <= v"9.1")
     error("""
     You have installed version $_GUROBI_VERSION of Gurobi, which is not
     supported by Gurobi.jl. We require Gurobi version 9 or greater.


### PR DESCRIPTION
Currently, Gurobi.jl will not build with the latest Gurobi release.

I am a bit uncertain about this change: https://github.com/jump-dev/Gurobi.jl/compare/v91?expand=1#diff-d94d3c5fbc186c74d77b476d8834210a084b9d673b46dbaa7a88e78664f62a14R20
