### PR TITLE
Make Optimizer.variable_info field a concrete type

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -138,7 +138,12 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     # A mapping from the MOI.VariableIndex to the Gurobi column. _VariableInfo
     # also stores some additional fields like what bounds have been added, the
     # variable type, and the names of SingleVariable-in-Set constraints.
-    variable_info::CleverDicts.CleverDict{MOI.VariableIndex, _VariableInfo, typeof(_HASH), typeof(_INVERSE_HASH)}
+    variable_info::CleverDicts.CleverDict{
+        MOI.VariableIndex,
+        _VariableInfo,
+        typeof(_HASH),
+        typeof(_INVERSE_HASH),
+    }
 
     # If you add variables to a model that had variables deleted AND has
     # not called `update_model!` since the deletion, then the newly created

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -239,7 +239,8 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
             model.params[string(name)] = value
         end
         model.silent = false
-        model.variable_info = CleverDicts.CleverDict{MOI.VariableIndex, _VariableInfo}(_HASH, _INVERSE_HASH)
+        model.variable_info =
+            CleverDicts.CleverDict{MOI.VariableIndex,_VariableInfo}(_HASH, _INVERSE_HASH)
         model.next_column = 1
         model.last_constraint_index = 1
         model.columns_deleted_since_last_update = Int[]


### PR DESCRIPTION
Before, `Optimizer.variable_info::CleverDicts.CleverDict{MOI.VariableIndex,_VariableInfo}` was not a concrete type since the last two type parameters (for the hash and reverse_hash functions) were omitted. This lead to type instability, most notably for me in `_update_if_necessary`. Here's a pprof snippet from a larger program that solves a number of relatively easy LPs:

<img width="1520" alt="Screen Shot 2021-01-05 at 9 48 40 AM" src="https://user-images.githubusercontent.com/1373010/103663224-7a15a800-4f36-11eb-80af-b41e70d01de2.png">

This change 1) specifies a concrete type for `variable_info` and 2) changes the constructor called to make this work. The hash/reverse hash functions are identical to what would be used anyway by the originally used constructor.

Pprof after the change:

<img width="1520" alt="Screen Shot 2021-01-05 at 9 52 42 AM" src="https://user-images.githubusercontent.com/1373010/103663470-bd701680-4f36-11eb-9a0e-72dd85f65335.png">
