### PR TITLE
Add method to MOI.add_constrained_variable

### DIFF
--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -709,9 +709,14 @@ function MOI.add_variables(model::Optimizer, N::Int)
     return indices
 end
 
+# We implement a specialized version here to avoid calling into Gurobi twice.
+# Using the standard implementation, we would first create a variable in Gurobi
+# with GRBaddvar that has bounds of (-Inf,+Inf), and then immediately after
+# reset those bounds using the attributes interface. Instead, we just pass the
+# desired bounds directly to GRBaddvar.
 function MOI.add_constrained_variable(
     model::Optimizer, set::S
-) where {S <: _SCALAR_SETS}
+)::Tuple{MOI.VariableIndex,MOI.ConstraintIndex{MOI.SingleVariable, S}} where {S <: _SCALAR_SETS}
     vi = CleverDicts.add_item(
         model.variable_info, _VariableInfo(MOI.VariableIndex(0), 0)
     )

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -715,8 +715,12 @@ end
 # reset those bounds using the attributes interface. Instead, we just pass the
 # desired bounds directly to GRBaddvar.
 function MOI.add_constrained_variable(
-    model::Optimizer, set::S
-)::Tuple{MOI.VariableIndex,MOI.ConstraintIndex{MOI.SingleVariable, S}} where {S <: _SCALAR_SETS}
+    model::Optimizer,
+    set::S,
+)::Tuple{
+    MOI.VariableIndex,
+    MOI.ConstraintIndex{MOI.SingleVariable,S},
+} where {S<:_SCALAR_SETS}
     vi = CleverDicts.add_item(
         model.variable_info, _VariableInfo(MOI.VariableIndex(0), 0)
     )

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -744,10 +744,6 @@ function MOI.add_constrained_variable(
     _require_update(model)
     ci = MOI.ConstraintIndex{MOI.SingleVariable, typeof(set)}(vi.value)
     return vi, ci
-    # This sets the bounds in the inner model and set the cache in _VariableInfo
-    # again (we could just set them there, but then _VariableInfo is in a
-    # invalid state that trigger some asserts, i.e., has bound but no cache).
-    MOI.set(model, MOI.ConstraintSet(), index, s)
 end
 
 function MOI.is_valid(model::Optimizer, v::MOI.VariableIndex)

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -722,23 +722,27 @@ function MOI.add_constrained_variable(
     lb = -Inf
     ub = Inf
     if S <: MOI.LessThan{Float64}
-        info.bound = _LESS_THAN
         ub = set.upper
+        info.upper_bound_if_bounded = ub
+        info.bound = _LESS_THAN
     elseif S <: MOI.GreaterThan{Float64}
-        info.bound = _GREATER_THAN
         lb = set.lower
+        info.lower_bound_if_bounded = lb
+        info.bound = _GREATER_THAN
     elseif S <: MOI.EqualTo{Float64}
-        info.bound = _EQUAL_TO
         lb = set.value
         ub = set.value
+        info.lower_bound_if_bounded = lb
+        info.upper_bound_if_bounded = ub
+        info.bound = _EQUAL_TO
     else
         @assert S <: MOI.Interval{Float64}
-        info.bound = _INTERVAL
         lb = set.lower
         ub = set.upper
+        info.lower_bound_if_bounded = lb
+        info.upper_bound_if_bounded = ub
+        info.bound = _INTERVAL
     end
-    info.lower_bound_if_bounded = lb
-    info.upper_bound_if_bounded = ub
     ret = GRBaddvar(model, 0, C_NULL, C_NULL, 0.0, lb, ub, GRB_CONTINUOUS, "")
     _check_ret(model, ret)
     _require_update(model)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1526,7 +1526,8 @@ function test_add_constrained_variables()
     set = MOI.Interval{Float64}(-1.2, 3.4)
     vi, ci = MOI.add_constrained_variable(model, set)
     @test MOI.get(model, MOI.NumberOfVariables()) == 1
-    @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.SingleVariable, MOI.Interval{Float64})]
+    @test MOI.get(model, MOI.ListOfConstraints()) ==
+          [(MOI.SingleVariable, MOI.Interval{Float64})]
     @test MOI.get(model, MOI.ConstraintFunction(), ci) == MOI.SingleVariable(vi)
     @test MOI.get(model, MOI.ConstraintSet(), ci) == set
 end

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1520,6 +1520,17 @@ function test_set_basis()
     end
 end
 
+function test_add_constrained_variables()
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    set = MOI.Interval{Float64}(-1.2, 3.4)
+    vi, ci = MOI.add_constrained_variable(model, set)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    @test MOI.get(model, MOI.ListOfConstraints()) == [(MOI.SingleVariable, MOI.Interval{Float64})]
+    @test MOI.get(model, MOI.ConstraintFunction(), ci) == MOI.SingleVariable(vi)
+    @test MOI.get(model, MOI.ConstraintSet(), ci) == set
+end
+
 end
 
 runtests(TestMOIWrapper)


### PR DESCRIPTION
While doing some benchmarking, I noticed that calling `MOI.add_constrained_variable(::Gurobi.Optimizer, set::Gurobi._SCALAR_SET)` was spending roughly the same amount of time in `GRBaddvar` as it was in setting the bound attributes. This seemed a bit wasteful, so I added a new method that lives here that sets the bounds directly in `GRBaddvar`.

I'm a bit uncertain how to update `lower_bound_if_bounded` and `upper_bound_if_bounded`. The comments for `_VariableInfo` suggest that these fields should be NaN if and only if a variable has no bound constraints on it. That will never be the case in this method, so therefore I should set both bound values, even to +/-Inf for one-sided bounds. However, after looking through the rest of the file I'm not certain that this is the behavior actually implemented in, e.g., 
```
MOI.set(::Optimizer, ::MOI.ConstraintSet, ::MOI.ConstraintIndex{MOI.SingleVariable, S}, s::S) where {S <: Gurobi._SCALAR_SETS}
```
So, guidance would be appreciated on what I should do there.