### PR TITLE
[MOI] Allow accessing multiple results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gurobi"
 uuid = "2e9cd046-0924-5485-92f1-d5272153d98b"
 repo = "https://github.com/jump-dev/Gurobi.jl"
-version = "0.9.7"
+version = "0.9.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/MOI_wrapper.jl
+++ b/src/MOI_wrapper.jl
@@ -2533,32 +2533,21 @@ function _has_primal_ray(model::Optimizer)
     return ret == 0
 end
 
-function _get_dbl_attr_variable(
-    model::Optimizer, key::String, x::MOI.VariableIndex
+function MOI.get(
+    model::Optimizer, attr::MOI.VariablePrimal, x::MOI.VariableIndex
 )
+    _throw_if_optimize_in_progress(model, attr)
+    MOI.check_result_index_bounds(model, attr)
+    key = model.has_unbounded_ray ? "UnbdRay" : "X"
+    if attr.N > 1
+        MOI.set(model, MOI.RawParameter("SolutionNumber"), attr.N - 1)
+        key = "Xn"
+    end
     col = Cint(column(model, x) - 1)
     valueP = Ref{Cdouble}()
     ret = GRBgetdblattrelement(model, key, col, valueP)
     _check_ret(model, ret)
     return valueP[]
-end
-
-function MOI.get(
-    model::Optimizer, attr::MOI.VariablePrimal, x::MOI.VariableIndex
-)
-    _throw_if_optimize_in_progress(model, attr)
-    if model.has_unbounded_ray
-        return _get_dbl_attr_variable(model, "UnbdRay", x)
-    end
-    result_count = MOI.get(model, MOI.ResultCount())
-    if !(1 <= attr.N <= result_count)
-        throw(MOI.ResultIndexBoundsError(attr, result_count))
-    elseif attr.N == 1
-        return _get_dbl_attr_variable(model, "X", x)
-    else
-        MOI.set(model, MOI.RawParameter("SolutionNumber"), attr.N - 1)
-        return _get_dbl_attr_variable(model, "Xn", x)
-    end
 end
 
 function MOI.get(
@@ -2777,21 +2766,15 @@ end
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
     _throw_if_optimize_in_progress(model, attr)
-    result_count = MOI.get(model, MOI.ResultCount())
-    if !(1 <= attr.result_index <= result_count)
-        throw(MOI.ResultIndexBoundsError(attr, result_count))
-    elseif attr.result_index == 1
-        valueP = Ref{Cdouble}()
-        ret = GRBgetdblattr(model, "ObjVal", valueP)
-        _check_ret(model, ret)
-        return valueP[]
-    else
+    MOI.check_result_index_bounds(model, attr)
+    if attr.result_index > 1
         MOI.set(model, MOI.RawParameter("SolutionNumber"), attr.result_index - 1)
-        valueP = Ref{Cdouble}()
-        ret = GRBgetdblattr(model, "PoolObjVal", valueP)
-        _check_ret(model, ret)
-        return valueP[]
     end
+    valueP = Ref{Cdouble}()
+    key = attr.result_index == 1 ? "ObjVal" : "PoolObjVal"
+    ret = GRBgetdblattr(model, key, valueP)
+    _check_ret(model, ret)
+    return valueP[]
 end
 
 function MOI.get(model::Optimizer, attr::MOI.ObjectiveBound)


### PR DESCRIPTION
Solves JuMP roadmap item "Accessing multiple results from solvers."

Here's what the test looks like at the JuMP level:
```Julia
using JuMP, Gurobi, Random, Test

function _is_binary(x; atol = 1e-6)
    return isapprox(x, 0; atol = atol) || isapprox(x, 1; atol = atol)
end

N = 30
Random.seed!(1)
item_weights, item_values = rand(N), rand(N)

model = Model(Gurobi.Optimizer)
@variable(model, x[1:N], Bin, start = 0)
@constraint(model, item_weights' * x <= 10)
@objective(model, Max, item_values' * x)
optimize!(model)
RC = result_count(model)
@test RC > 1

for n in [0, RC + 1]
    @test_throws MOI.ResultIndexBoundsError value.(x; result = n)
    @test_throws MOI.ResultIndexBoundsError objective_value(model; result = n)
end

for n = 1:RC
    xn = value.(x; result = n)
    @test all(_is_binary, xn)
    @test isapprox(
        objective_value(model; result = n),
        item_values' * xn,
        atol=1e-6,
    )
end
```

Tests pass:

![image](https://user-images.githubusercontent.com/8177701/106836529-357c5880-66fe-11eb-9d02-728a61fc29dc.png)
