### PR TITLE
Fix handling of solution statuses for multiple results

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gurobi"
 uuid = "2e9cd046-0924-5485-92f1-d5272153d98b"
 repo = "https://github.com/jump-dev/Gurobi.jl"
-version = "0.9.8"
+version = "0.9.9"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1572,6 +1572,8 @@ function test_multiple_solutions()
             MOI.ResultIndexBoundsError,
             MOI.get(model, MOI.ObjectiveValue(n)),
         )
+        @test MOI.get(model, MOI.PrimalStatus(n)) == MOI.NO_SOLUTION
+        @test MOI.get(model, MOI.DualStatus(n)) == MOI.NO_SOLUTION
     end
     for n = 1:RC
         xn = MOI.get(model, MOI.VariablePrimal(n), x)
@@ -1581,6 +1583,8 @@ function test_multiple_solutions()
             item_values' * xn,
             atol=1e-6,
         )
+        @test MOI.get(model, MOI.PrimalStatus(n)) == MOI.FEASIBLE_POINT
+        @test MOI.get(model, MOI.DualStatus(n)) == MOI.NO_SOLUTION
     end
 end
 


### PR DESCRIPTION
`PrimalStatus` always returned `NO_SOLUTION` if `.N != 1`.

![image](https://user-images.githubusercontent.com/8177701/107133852-686a5a80-6951-11eb-84bc-ae54c5dc5ae4.png)
