### PR TITLE
Allow retrieving conflict status for integrality constraints.

### DIFF
--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -462,7 +462,7 @@ function test_Conflict_refiner_integer_constraint()
 
     MOI.optimize!(model)
     MOI.compute_conflict!(model)
-    @test MOI.get(model, Gurobi.ConflictStatus()) == 0 # CPLEX.CPX_STAT_CONFLICT_MINIMAL
+    @test MOI.get(model, Gurobi.ConflictStatus()) == 0
     @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.MAYBE_IN_CONFLICT
     @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.IN_CONFLICT
 end

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -452,6 +452,23 @@ function test_Conflict_refiner_no_conflict()
     # @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
 end
 
+function test_Conflict_refiner_integer_constraint()
+    # Root problem: missing method to get the status for an integrality 
+    # constraint.
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    x, c1 = MOI.add_constrained_variable(model, MOI.ZeroOne())
+    c2 = MOI.add_constraint(model, MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.([1.0], [x]), 0.0), MOI.GreaterThan(2.0))
+
+    MOI.optimize!(model)
+    MOI.compute_conflict!(model)
+    @test MOI.get(model, Gurobi.ConflictStatus()) == 0 # CPLEX.CPX_STAT_CONFLICT_MINIMAL
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c1) == MOI.MAYBE_IN_CONFLICT
+    @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.IN_CONFLICT
+end
+
+@test false
+
 function test_RawParameter()
     model = Gurobi.Optimizer(GRB_ENV)
     @test MOI.get(model, MOI.RawParameter("OutputFlag")) == 1

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -467,8 +467,6 @@ function test_Conflict_refiner_integer_constraint()
     @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.IN_CONFLICT
 end
 
-@test false
-
 function test_RawParameter()
     model = Gurobi.Optimizer(GRB_ENV)
     @test MOI.get(model, MOI.RawParameter("OutputFlag")) == 1


### PR DESCRIPTION
Fixes an issue similar to https://github.com/jump-dev/CPLEX.jl/issues/365.

Mostly a copy-paste from https://github.com/jump-dev/CPLEX.jl/pull/367.