### PR TITLE
Error message when installing Gurobi.jl on 32-bit Julia.

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -6,6 +6,10 @@ if isfile(DEPS_FILE)
     rm(DEPS_FILE)
 end
 
+if Int === Int32
+    error("Gurobi.jl does not support 32-bit Julia. Please install a 64-bit Julia.")
+end
+
 function write_depsfile(path)
     open(DEPS_FILE, "w") do io
         println(io, "const libgurobi = \"$(escape_string(path))\"")


### PR DESCRIPTION
This should avoid issues like #387 (as it recently popped up in Gitter).