### PR TITLE
Improve error handling of license problems

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -100,11 +100,6 @@ mutable struct Env
     function Env()
         a = Ref{Ptr{Cvoid}}()
         ret = GRBloadenv(a, C_NULL)
-        if ret == 10009
-            error("Gurobi Error 10009: Failed to obtain a valid license")
-        elseif ret != 0
-            error("Gurobi Error $(ret): failed to create environment")
-        end
         env = new(a[], false, 0)
         finalizer(env) do e
             e.finalize_called = true
@@ -114,6 +109,8 @@ mutable struct Env
                 e.ptr_env = C_NULL
             end
         end
+        # Even if the loadenv fails, the pointer is still valid.
+        _check_ret(env, ret)
         return env
     end
 end


### PR DESCRIPTION
This crops up all the time: https://discourse.julialang.org/t/gurobi-license-issue/36547/8

I had just assumed the text of the error was coming from Gurobi, not us.

Closes #417