### PR TITLE
Run the lazy constraints callback at MIPNODE

### DIFF
--- a/src/MOI_wrapper/MOI_callbacks.jl
+++ b/src/MOI_wrapper/MOI_callbacks.jl
@@ -146,6 +146,10 @@ function _default_moi_callback(model::Optimizer)
                 model.callback_state = _CB_HEURISTIC
                 model.heuristic_callback(cb_data)
             end
+            if model.lazy_callback !== nothing
+                model.callback_state = _CB_LAZY
+                model.lazy_callback(cb_data)
+            end
         end
         model.callback_state = _CB_NONE
     end

--- a/test/MOI/MOI_callbacks.jl
+++ b/test/MOI/MOI_callbacks.jl
@@ -106,6 +106,32 @@ function test_lazy_constraint_callback()
     @test MOI.get(model, MOI.VariablePrimal(), y) == 2
 end
 
+function test_lazy_constraint_callback_fractional()
+    # callback_simple_model() is not large enough to see MIPNODE callbacks.
+    model, x, item_weights = callback_knapsack_model()
+    lazy_called_integer = false
+    lazy_called_fractional = false
+    MOI.set(
+        model,
+        MOI.LazyConstraintCallback(),
+        cb_data -> begin
+            status = MOI.get(
+                model,
+                MOI.CallbackNodeStatus(cb_data),
+            )::MOI.CallbackNodeStatusCode
+            if status == MOI.CALLBACK_NODE_STATUS_INTEGER
+                lazy_called_integer = true
+            elseif status == MOI.CALLBACK_NODE_STATUS_FRACTIONAL
+                lazy_called_fractional = true
+            end
+        end,
+    )
+    @test MOI.supports(model, MOI.LazyConstraintCallback())
+    MOI.optimize!(model)
+    @test lazy_called_integer
+    @test lazy_called_fractional
+end
+
 function test_lazy_constraint_callback_OptimizeInProgress()
     model, x, y = callback_simple_model()
     MOI.set(


### PR DESCRIPTION
Executes the lazy constraints callback (if defined) when where=MIPNODE so that the callback is executed at fractional values. Added a test using callback_knapsack_model to ensure some fractional solutions reach the callback in this example.

Note: branched this from v0.9.14 as v0.10.0 forces a downgrade to JuMP 0.18