### PR TITLE
Add MOI.modify for multiple changes at once

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3476,13 +3476,7 @@ function MOI.modify(
         cols[i] = Cint(column(model, changes[i].variable) - 1)
         coefs[i] = changes[i].new_coefficient
     end
-    ret = GRBchgcoeffs(
-        model,
-        nels,
-        rows,
-        cols,
-        coefs,
-    )
+    ret = GRBchgcoeffs(model, nels, rows, cols, coefs)
     _check_ret(model, ret)
     _require_update(model)
     return
@@ -3517,13 +3511,7 @@ function MOI.modify(
         cols[i] = Cint(column(model, changes[i].variable) - 1)
         coefs[i] = changes[i].new_coefficient
     end
-    ret = GRBsetdblattrlist(
-        model,
-        "Obj",
-        nels,
-        cols,
-        coefs,
-    )
+    ret = GRBsetdblattrlist(model, "Obj", nels, cols, coefs)
     _check_ret(model, ret)
     model.is_objective_set = true
     _require_update(model)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3464,27 +3464,24 @@ end
 function MOI.modify(
     model::Optimizer,
     cis::Vector{MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},S}},
-    chgs::Vector{MOI.ScalarCoefficientChange{Float64}},
+    changes::Vector{MOI.ScalarCoefficientChange{Float64}},
 ) where {S}
     nels = length(cis)
-    @assert nels == length(chgs)
-
-    rows = Vector{Int}(undef, nels)
-    cols = Vector{Int}(undef, nels)
-    coefs = Vector{Float64}(undef, nels)
-
+    @assert nels == length(changes)
+    rows = Vector{Cint}(undef, nels)
+    cols = Vector{Cint}(undef, nels)
+    coefs = Vector{Double}(undef, nels)
     for i in 1:nels
-        rows[i] = _info(model, c).row - 1
-        cols[i] = column(model, chgs[i].variable) - 1
-        coefs[i] = chgs[i].new_coefficient
+        rows[i] = Cint(_info(model, c).row - 1)
+        cols[i] = Cint(column(model, changes[i].variable) - 1)
+        coefs[i] = changes[i].new_coefficient
     end
-
     ret = GRBchgcoeffs(
         model,
         nels,
-        Ref{Cint}.(rows),
-        Ref{Cint}.(cols),
-        Ref{Cdouble}.(coefs),
+        rows,
+        cols,
+        coefs,
     )
     _check_ret(model, ret)
     _require_update(model)
@@ -3511,23 +3508,20 @@ end
 function MOI.modify(
     model::Optimizer,
     ::MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}},
-    chgs::Vector{MOI.ScalarCoefficientChange{Float64}},
+    changes::Vector{MOI.ScalarCoefficientChange{Float64}},
 )
-    nels = length(chgs)
-    
-    cols = Vector{Int}(undef, nels)
-    coefs = Vector{Float64}(undef, nels)
-
+    nels = length(changes)
+    cols = Vector{Cint}(undef, nels)
+    coefs = Vector{Double}(undef, nels)
     for i in 1:nels
-        cols[i] = column(model, chgs[i].variable) - 1
-        coefs[i] = chgs[i].new_coefficient
+        cols[i] = Cint(column(model, changes[i].variable) - 1)
+        coefs[i] = changes[i].new_coefficient
     end
-
     ret = GRBsetdblattrlist(
         model,
         "Obj",
         nels,
-        Cint.(cols),
+        cols,
         coefs,
     )
     _check_ret(model, ret)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3472,7 +3472,7 @@ function MOI.modify(
     cols = Vector{Cint}(undef, nels)
     coefs = Vector{Cdouble}(undef, nels)
     for i in 1:nels
-        rows[i] = Cint(_info(model, c).row - 1)
+        rows[i] = Cint(_info(model, cis[i]).row - 1)
         cols[i] = Cint(column(model, changes[i].variable) - 1)
         coefs[i] = changes[i].new_coefficient
     end

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3470,7 +3470,7 @@ function MOI.modify(
     @assert nels == length(changes)
     rows = Vector{Cint}(undef, nels)
     cols = Vector{Cint}(undef, nels)
-    coefs = Vector{Double}(undef, nels)
+    coefs = Vector{Cdouble}(undef, nels)
     for i in 1:nels
         rows[i] = Cint(_info(model, c).row - 1)
         cols[i] = Cint(column(model, changes[i].variable) - 1)
@@ -3506,7 +3506,7 @@ function MOI.modify(
 )
     nels = length(changes)
     cols = Vector{Cint}(undef, nels)
-    coefs = Vector{Double}(undef, nels)
+    coefs = Vector{Cdouble}(undef, nels)
     for i in 1:nels
         cols[i] = Cint(column(model, changes[i].variable) - 1)
         coefs[i] = changes[i].new_coefficient

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -647,6 +647,61 @@ function test_log_file()
     return
 end
 
+function test_multiple_modifications()
+    model = Gurobi.Optimizer(GRB_ENV)
+
+    x = MOI.add_variables(model, 3)
+
+    saf = MOI.ScalarAffineFunction(
+        [
+            MOI.ScalarAffineTerm(1.0, x[1]),
+            MOI.ScalarAffineTerm(1.0, x[2]),
+            MOI.ScalarAffineTerm(1.0, x[3]),
+        ],
+        0.0,
+    )
+    ci1 = MOI.add_constraint(model, saf, MOI.LessThan(1.0))
+    ci2 = MOI.add_constraint(model, saf, MOI.LessThan(2.0))
+
+    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), saf)
+
+    fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
+    @test MOI.coefficient.(fc1.terms) == [1.0, 1.0, 1.0]
+    fc2 = MOI.get(model, MOI.ConstraintFunction(), ci2)
+    @test MOI.coefficient.(fc2.terms) == [1.0, 1.0, 1.0]
+    obj = MOI.get(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+    )
+    @test MOI.coefficient.(obj.terms) == [1.0, 1.0, 1.0]
+
+    changes_cis = [
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(1), 4.0)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(1), 0.5)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(3), 2.0)
+    ]
+    MOI.modify(model, [ci1, ci2, ci2], changes_cis)
+
+    fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
+    @test MOI.coefficient.(fc1.terms) == [4.0, 1.0, 1.0]
+    fc2 = MOI.get(model, MOI.ConstraintFunction(), ci2)
+    @test MOI.coefficient.(fc2.terms) == [0.5, 1.0, 2.0]
+
+    changes_obj = [
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(1), 4.0)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(2), 10.0)
+        MOI.ScalarCoefficientChange(MOI.VariableIndex(3), 2.0)
+    ]
+    MOI.modify(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        changes_obj,
+    )
+
+    obj = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    @test MOI.coefficient.(obj.terms) == [4.0, 10.0, 2.0]
+end
+
 end
 
 TestMOIWrapper.runtests()

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -663,7 +663,11 @@ function test_multiple_modifications()
     ci1 = MOI.add_constraint(model, saf, MOI.LessThan(1.0))
     ci2 = MOI.add_constraint(model, saf, MOI.LessThan(2.0))
 
-    MOI.set(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(), saf)
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        saf,
+    )
 
     fc1 = MOI.get(model, MOI.ConstraintFunction(), ci1)
     @test MOI.coefficient.(fc1.terms) == [1.0, 1.0, 1.0]
@@ -698,7 +702,10 @@ function test_multiple_modifications()
         changes_obj,
     )
 
-    obj = MOI.get(model, MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}())
+    obj = MOI.get(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+    )
     @test MOI.coefficient.(obj.terms) == [4.0, 10.0, 2.0]
 end
 


### PR DESCRIPTION
This is a follow-up from https://github.com/jump-dev/MathOptInterface.jl/pull/1800
It significantly improved the performance of updates. Using the same code from the PR above:
```julia
julia> @btime update_parameters_multiple_times_with_single_change(num_variables, num_solves)
  18.970 ms (55878 allocations: 7.52 MiB)

julia> @btime update_parameters_multiple_times_with_multiple_changes(num_variables, num_solves)
  6.163 ms (5786 allocations: 2.64 MiB)
```