### PR TITLE
Switch to LazyArtifacts

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,9 +4,9 @@ repo = "https://github.com/jump-dev/Gurobi.jl"
 version = "0.11.3"
 
 [deps]
+LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 
 [compat]
 MathOptInterface = "1"

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -6,7 +6,7 @@
 
 module Gurobi
 
-import Pkg
+import LazyArtifacts
 
 # deps.jl file is always built via `Pkg.build`, even if we didn't find a local
 # install and we want to use the artifact instead. This is so Gurobi.jl will be
@@ -18,7 +18,7 @@ if isdefined(@__MODULE__, :libgurobi)
 elseif Sys.islinux()
     # Let's use the artifact instead.
     const libgurobi = joinpath(
-        Pkg.Artifacts.artifact"gurobilinux64",
+        LazyArtifacts.artifact"gurobilinux64",
         "gurobi951/linux64/lib/libgurobi95.so",
     )
 else


### PR DESCRIPTION
Using the stdlib is preferred over `Pkg.Artifacts`.