### PR TITLE
Add support for Absolute/Relative gap tolerances

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-MathOptInterface = "1.6.1"
+MathOptInterface = "1.7"
 julia = "1.6"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-MathOptInterface = "1"
+MathOptInterface = "1.6.1"
 julia = "1.6"
 
 [extras]

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -622,6 +622,8 @@ MOI.supports(::Optimizer, ::MOI.Name) = true
 MOI.supports(::Optimizer, ::MOI.Silent) = true
 MOI.supports(::Optimizer, ::MOI.NumberOfThreads) = true
 MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
+MOI.supports(::Optimizer, ::MOI.AbsoluteGapTolerance) = true
+MOI.supports(::Optimizer, ::MOI.RelativeGapTolerance) = true
 MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true
 MOI.supports(::Optimizer, ::MOI.RawOptimizerAttribute) = true
 MOI.supports(::Optimizer, ::MOI.ConstraintPrimalStart) = false
@@ -3188,6 +3190,24 @@ end
 
 function MOI.set(model::Optimizer, ::MOI.NumberOfThreads, ::Nothing)
     MOI.set(model, MOI.RawOptimizerAttribute("Threads"), 0)
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.AbsoluteGapTolerance)
+    return MOI.get(model, MOI.RawOptimizerAttribute("MIPGapAbs"))
+end
+
+function MOI.set(model::Optimizer, ::MOI.AbsoluteGapTolerance, value::Real)
+    MOI.set(model, MOI.RawOptimizerAttribute("MIPGapAbs"), value)
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.RelativeGapTolerance)
+    return MOI.get(model, MOI.RawOptimizerAttribute("MIPGap"))
+end
+
+function MOI.set(model::Optimizer, ::MOI.RelativeGapTolerance, value::Real)
+    MOI.set(model, MOI.RawOptimizerAttribute("MIPGap"), value)
     return
 end
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3144,6 +3144,11 @@ function MOI.get(model::Optimizer, attr::MOI.RelativeGap)
     return valueP[]
 end
 
+function MOI.set(model::Optimizer, ::MOI.RelativeGap, gap::Real)
+    MOI.set(model, MOI.RawOptimizerAttribute("MIPGap"), gap)
+    return nothing
+end
+
 function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3144,11 +3144,6 @@ function MOI.get(model::Optimizer, attr::MOI.RelativeGap)
     return valueP[]
 end
 
-function MOI.set(model::Optimizer, ::MOI.RelativeGap, gap::Real)
-    MOI.set(model, MOI.RawOptimizerAttribute("MIPGap"), gap)
-    return nothing
-end
-
 function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)


### PR DESCRIPTION
I went for the easy way: fall back to the `RawOptimizerAttribute`

___

EDIT: I have updated the PR to follow the conclusions of https://github.com/jump-dev/MathOptInterface.jl/issues/1936
At the moment, the present branch only works with `MOI#master`