### PR TITLE
Bump binaries to v10.0.0

### DIFF
--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,8 +1,8 @@
 [gurobilinux64]
-git-tree-sha1 = "612b2b4f80fd7b9d6c2f765124b7c2905dce80c7"
+git-tree-sha1 = "e1ea344a512fd4849fd788ddbe04e5f2c0d986b2"
 os = "linux"
 lazy = true
 
     [[gurobilinux64.download]]
-    url = "https://packages.gurobi.com/9.5/gurobi9.5.1_linux64.tar.gz"
-    sha256 = "fa82859d33f08fb8aeb9da66b0fbd91718ed573c534f571aa52372c9deb891da"
+    url = "https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz"
+    sha256 = "91a9ce1464f5f948809fcdfbdeb55f77698ed8a6d6cfa6985295424b6ece2bd4"

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -19,7 +19,7 @@ elseif Sys.islinux()
     # Let's use the artifact instead.
     const libgurobi = joinpath(
         LazyArtifacts.artifact"gurobilinux64",
-        "gurobi951/linux64/lib/libgurobi95.so",
+        "gurobi1000/linux64/lib/libgurobi100.so",
     )
 else
     error("""
@@ -31,7 +31,7 @@ end
 const _GUROBI_VERSION = if libgurobi == "__skipped_installation__"
     # The deps file is fake, with the intention to make Gurobi.jl loadable but
     # not usable.
-    VersionNumber(9, 5, 1)
+    VersionNumber(10, 0, 0)
 else
     let
         majorP, minorP, technicalP = Ref{Cint}(), Ref{Cint}(), Ref{Cint}()


### PR DESCRIPTION
```julia
run(`wget https://packages.gurobi.com/10.0/gurobi10.0.0_linux64.tar.gz`)
using Tar, Inflate, SHA
filename = "gurobi10.0.0_linux64.tar.gz"
println("sha256: ", bytes2hex(open(sha256, filename)))
println("git-tree-sha1: ", Tar.tree_hash(IOBuffer(inflate_gzip(filename))))
```