### PR TITLE
Prep for v1.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Gurobi"
 uuid = "2e9cd046-0924-5485-92f1-d5272153d98b"
 repo = "https://github.com/jump-dev/Gurobi.jl"
-version = "0.11.5"
+version = "1.0.0"
 
 [deps]
 LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"


### PR DESCRIPTION
For most users this should be non-breaking. 

The only breakage is https://github.com/jump-dev/Gurobi.jl/pull/497, in which querying `ObjectiveValue` of a multi-objective optimization problem now returns a vector instead of the objective value of the first scalar objective.

This also has a minimal impact on the Pkg ecosystem because there is only one package with a dependency: https://juliahub.com/ui/Packages/Gurobi/do9v6/0.11.5 (cc @JoshKImperial for https://github.com/infrasenselabs/RoundAndSwap.jl) 