### PR TITLE
Use Gurobi_jll for binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,21 +14,32 @@ jobs:
     runs-on: 'ubuntu-latest'
     strategy:
       fail-fast: false
+      matrix:
+        version: ['1.6', '1']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        arch: [x64]
+        include:
+         - version: '1'
+           os: macos-14
+           arch: aarch64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
-          version: '1'
-          arch: 'x64'
-      - uses: julia-actions/cache@v1
-      - shell: bash
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      # - uses: julia-actions/cache@v1
+      # - uses: julia-actions/julia-buildpkg@v1
+      # - uses: julia-actions/julia-runtest@v1
+      - name: Test
+        shell: julia --color=yes --project=. {0}
         env:
           WLSLICENSE: ${{ secrets.WLSLICENSE }}
         run: |
-          mkdir -p /opt/gurobi
-          echo "$WLSLICENSE" > /opt/gurobi/gurobi.lic
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
+          import Pkg
+          Pkg.pkg"add https://github.com/jump-dev/Gurobi_jll.jl"
+          Pkg.pkg"build Gurobi"
+          Pkg.test()
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,18 +28,11 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      # - uses: julia-actions/cache@v1
-      # - uses: julia-actions/julia-buildpkg@v1
-      # - uses: julia-actions/julia-runtest@v1
-      - name: Test
-        shell: julia --color=yes --project=. {0}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@v1
+      - uses: julia-actions/julia-runtest@v1
         env:
           WLSLICENSE: ${{ secrets.WLSLICENSE }}
-        run: |
-          import Pkg
-          Pkg.pkg"add https://github.com/jump-dev/Gurobi_jll.jl"
-          Pkg.pkg"build Gurobi"
-          Pkg.test()
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,8 @@ jobs:
         version: ['1.6', '1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
-        jll_version: ['9.5.2', '10.0.3']
+        # v9.5.2 does not support the web license service
+        jll_version: ['10.0.3']
         include:
          - version: '1'
            os: macos-14
@@ -36,6 +37,7 @@ jobs:
           import Pkg
           Pkg.add(; name = "Gurobi_jll", version = ENV["GUROBI_JLL_VERSION"])
         env:
+          GUROBI_JL_SKIP_LIB_CHECK: "true"
           GUROBI_JLL_VERSION: ${{ matrix.jll_version }}
       - uses: julia-actions/julia-buildpkg@v1
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
         # v9.5.2 does not support the web license service
-        jll_version: ['10.0.3']
+        jll_version: ['10.0.3', '11.0.1']
         include:
          - version: '1'
            os: macos-14
            arch: aarch64
-           jll_version: '10.0.3'
+           jll_version: '11.0.1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,9 +30,9 @@ jobs:
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
         env:
           WLSLICENSE: ${{ secrets.WLSLICENSE }}
+      - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,20 @@ permissions:
   contents: read
 jobs:
   test:
-    name: 'Gurobi'
-    runs-on: 'ubuntu-latest'
+    name: Julia ${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.jll_version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version: ['1.6', '1']
         os: [ubuntu-latest, macOS-latest, windows-latest]
         arch: [x64]
+        jll_version: ['9.5.2', '10.0.3']
         include:
          - version: '1'
            os: macos-14
            arch: aarch64
+           jll_version: '10.0.3'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
@@ -29,6 +31,12 @@ jobs:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
       - uses: julia-actions/cache@v1
+      - shell: julia --project=. --color=yes {0}
+        run: |
+          import Pkg
+          Pkg.add(; name = "Gurobi_jll", version = ENV["GUROBI_JLL_VERSION"])
+        env:
+          GUROBI_JLL_VERSION: ${{ matrix.jll_version }}
       - uses: julia-actions/julia-buildpkg@v1
         env:
           WLSLICENSE: ${{ secrets.WLSLICENSE }}

--- a/Artifacts.toml
+++ b/Artifacts.toml
@@ -1,8 +1,0 @@
-[gurobilinux64]
-git-tree-sha1 = "79f6322f611b73845e645125d5a54f17b16f6428"
-os = "linux"
-lazy = true
-
-    [[gurobilinux64.download]]
-    url = "https://packages.gurobi.com/11.0/gurobi11.0.0_linux64.tar.gz"
-    sha256 = "6a1ec7499b230aea0542bc893bf0642ae8ce983dd5ef0c37cb3a253d827ce634"

--- a/Project.toml
+++ b/Project.toml
@@ -4,12 +4,11 @@ repo = "https://github.com/jump-dev/Gurobi.jl"
 version = "1.2.3"
 
 [deps]
-LazyArtifacts = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+Gurobi_jll = "c018c7e6-a5b0-4aea-8f80-9c1ef9991411"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-LazyArtifacts = "<0.0.1, 1.6"
 Libdl = "<0.0.1, 1.6"
 MathOptInterface = "1.12"
 Random = "<0.0.1, 1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
-Gurobi_jll = "=9.5.2"
+Gurobi_jll = "~9.5, ~10.0, ~11.0"
 Libdl = "<0.0.1, 1.6"
 MathOptInterface = "1.12"
 Random = "<0.0.1, 1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 
 [compat]
+Gurobi_jll = "=9.5.2"
 Libdl = "<0.0.1, 1.6"
 MathOptInterface = "1.12"
 Random = "<0.0.1, 1.6"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,35 @@ Free Gurobi licenses are available for [academics and students](https://www.guro
 
 ## Installation
 
-First, obtain a license of Gurobi and install Gurobi solver.
+To use Gurobi, you need a license. To install the license, first obtain a key
+from [gurobi.com](https://www.gurobi.com), then run:
+```julia
+import Pkg
+Pkg.add("Gurobi_jll")
+import Gurobi_jll
+# Replace the contents xxxxx with your actual key
+key = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+run(`$(Gurobi_jll.grbgetkey()) $key`)
+```
 
-Then, set the `GUROBI_HOME` environment variable as appropriate and run
-`Pkg.add("Gurobi")`:
+### Default installation
+
+Install Gurobi as follows:
+```julia
+import Pkg
+Pkg.add("Gurobi")
+```
+
+In addition to installing the Gurobi.jl package, this will also download and
+install the Gurobi binaries from [Gurobi_jll.jl](https://github.com/jump-dev/Gurobi_jll.jl).
+You do not need to install Gurobi separately.
+
+### Manual installation
+
+To opt-out of using the Gurobi_jll binaries, set the `GUROBI_HOME` environment
+variable to point to your local installation and set the
+`GUROBI_JL_USE_GUROBI_JLL` environment variable to `"false"`, then run
+`Pkg.add` and `Pkg.build`:
 
 ```julia
 # On Windows, this might be
@@ -48,20 +73,15 @@ ENV["GUROBI_HOME"] = "C:\\Program Files\\gurobi1100\\win64"
 # ... or perhaps ...
 ENV["GUROBI_HOME"] = "C:\\gurobi1100\\win64"
 # On Mac, this might be
-ENV["GUROBI_HOME"] = "/Library/gurobi1100/mac64"
+ENV["GUROBI_HOME"] = "/Library/gurobi1100/macos_universal2"
+
+# Opt-out of using Gurobi_jll
+ENV["GUROBI_JL_USE_GUROBI_JLL"] = "false"
 
 import Pkg
 Pkg.add("Gurobi")
+Pkg.build("Gurobi")
 ```
-**Note: your path may differ. Check which folder you installed Gurobi in, and
-update the path accordingly.**
-
-By default, building Gurobi.jl will fail if the Gurobi library is not found.
-This may not be desirable in certain cases, for example when part of a package's
-test suite uses Gurobi as an optional test dependency, but Gurobi cannot be
-installed on a CI server running the test suite. To support this use case, the
-`GUROBI_JL_SKIP_LIB_CHECK` environment variable may be set (to any value) to
-make Gurobi.jl installable (but not usable).
 
 ## Use with JuMP
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -172,7 +172,11 @@ if haskey(ENV, "GUROBI_JL_SKIP_LIB_CHECK")
 elseif get(ENV, "JULIA_REGISTRYCI_AUTOMERGE", "false") == "true"
     # We write a fake depsfile so Gurobi.jl is loadable but not usable.
     write_depsfile("__skipped_installation__")
-elseif !found && Sys.islinux()
+elseif !found && (Sys.islinux() || Sys.isapple() || Sys.iswindows())
+    if haskey(ENV, "WLSLICENSE")
+        home = Sys.iswindows() ? ENV["USERPROFILE"] : ENV["HOME"]
+        write(joinpath(home, "gurobi.lic"), ENV["WLSLICENSE"])
+    end
     open(DEPS_FILE, "w") do io
         println(io, "# No libgurobi constant; we're using the Artifact.")
     end

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -17,10 +17,10 @@ elseif Sys.islinux() || Sys.isapple() || Sys.iswindows()
     import Gurobi_jll
     const libgurobi = Gurobi_jll.libgurobi
 else
-    error("""
-        Gurobi not properly installed. Please run Pkg.build(\"Gurobi\"). For
-        more information go to https://github.com/jump-dev/Gurobi.jl
-    """)
+    error(
+        "Unsupported platform: Use a manual installation by setting " *
+        "`GUROBI_JL_USE_GUROBI_JLL` to false. See the README for details.",
+    )
 end
 
 const _GUROBI_VERSION = if libgurobi == "__skipped_installation__"

--- a/src/Gurobi.jl
+++ b/src/Gurobi.jl
@@ -6,8 +6,6 @@
 
 module Gurobi
 
-import LazyArtifacts
-
 # deps.jl file is always built via `Pkg.build`, even if we didn't find a local
 # install and we want to use the artifact instead. This is so Gurobi.jl will be
 # recompiled if we update the file. See issue #438 for more details.
@@ -15,12 +13,9 @@ include(joinpath(dirname(@__FILE__), "..", "deps", "deps.jl"))
 
 if isdefined(@__MODULE__, :libgurobi)
     # deps.jl must define a local installation.
-elseif Sys.islinux()
-    # Let's use the artifact instead.
-    const libgurobi = joinpath(
-        LazyArtifacts.artifact"gurobilinux64",
-        "gurobi1100/linux64/lib/libgurobi110.so",
-    )
+elseif Sys.islinux() || Sys.isapple() || Sys.iswindows()
+    import Gurobi_jll
+    const libgurobi = Gurobi_jll.libgurobi
 else
     error("""
         Gurobi not properly installed. Please run Pkg.build(\"Gurobi\"). For


### PR DESCRIPTION
See https://github.com/jump-dev/Gurobi_jll.jl

There are still a few unresolved issues:

 - [x] Tag a release of Gurobi_jll
 - [x] Check if binaries are installed on `Pkg.add`, or only if needed
 - [x] Document how to set a license if using provided binaries
 - [x] Test locally

A potential first-pass is to use the binaries only on CI (or linux, to maintain compat).

Would fix issues like 
https://discourse.julialang.org/t/how-to-use-gurobi-11-in-julia-launched-by-anaconda/111271/2

Closes #509