### PR TITLE
WIP. Refactor GRBupdatemodel calls

### DIFF
--- a/src/MOI_wrapper/MOI_multi_objective.jl
+++ b/src/MOI_wrapper/MOI_multi_objective.jl
@@ -36,7 +36,6 @@ function MOI.set(
         obj[column] += term.coefficient
     end
     indices, coefficients = _indices_and_coefficients(model, f)
-    _update_if_necessary(model)
     ret = GRBsetobjectiven(
         model,
         Cint(attr.index - 1),


### PR DESCRIPTION
WIP.
The idea is to only call `GRBupdatemodel` before `GRBget*`.
Some tests are failing still: 
- [ ] `test_Buffered_deletion_test`, `test_modify_after_delete*` (indexing should also be updated with delete? This is not expected from our other APIs)

Fixes https://github.com/jump-dev/Gurobi.jl/issues/516