### PR TITLE
Refactor GRBupdatemodel calls

### DIFF
--- a/src/MOI_wrapper/MOI_callbacks.jl
+++ b/src/MOI_wrapper/MOI_callbacks.jl
@@ -83,7 +83,7 @@ function MOI.set(model::Optimizer, ::CallbackFunction, f::Function)
     model.generic_callback = user_data
     model.has_generic_callback = true
     # Mark the update as necessary and immediately call for the update.
-    _require_update(model)
+    _require_update(model, model_change = true)
     _update_if_necessary(model)
     return
 end

--- a/src/MOI_wrapper/MOI_indicator_constraint.jl
+++ b/src/MOI_wrapper/MOI_indicator_constraint.jl
@@ -140,7 +140,7 @@ function MOI.add_constraint(
     model.last_constraint_index += 1
     info = _ConstraintInfo(length(model.indicator_constraint_info) + 1, s)
     model.indicator_constraint_info[model.last_constraint_index] = info
-    _require_update(model)
+    _require_update(model, model_change = true)
     return MOI.ConstraintIndex{typeof(func),typeof(s)}(
         model.last_constraint_index,
     )
@@ -180,7 +180,7 @@ function MOI.set(
     name::String,
 ) where {S<:MOI.Indicator}
     MOI.throw_if_not_valid(model, c)
-    _update_if_necessary(model)
+    _update_if_necessary(model, check_attribute_change = false)
     info = _info(model, c)
     info.name = name
     if !isempty(name)
@@ -188,6 +188,7 @@ function MOI.set(
         ret = GRBsetstrattrelement(model, "GenConstrName", row, name)
         _check_ret(model, ret)
     end
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -195,7 +196,6 @@ function MOI.delete(
     model::Optimizer,
     c::MOI.ConstraintIndex{<:MOI.VectorAffineFunction,<:MOI.Indicator},
 )
-    _update_if_necessary(model)
     MOI.throw_if_not_valid(model, c)
     row = _info(model, c).row
     ind = Ref{Cint}(row - 1)
@@ -207,6 +207,6 @@ function MOI.delete(
             info.row -= 1
         end
     end
-    _require_update(model)
+    _update_if_necessary(model, force = true)
     return
 end

--- a/src/MOI_wrapper/MOI_multi_objective.jl
+++ b/src/MOI_wrapper/MOI_multi_objective.jl
@@ -50,7 +50,7 @@ function MOI.set(
         coefficients,
     )
     _check_ret(model, ret)
-    _require_update(model)
+    _require_update(model, model_change = true)
     return
 end
 

--- a/src/MOI_wrapper/MOI_multi_objective.jl
+++ b/src/MOI_wrapper/MOI_multi_objective.jl
@@ -36,7 +36,6 @@ function MOI.set(
         obj[column] += term.coefficient
     end
     indices, coefficients = _indices_and_coefficients(model, f)
-    _update_if_necessary(model)
     ret = GRBsetobjectiven(
         model,
         Cint(attr.index - 1),

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1038,6 +1038,7 @@ function MOI.delete(model::Optimizer, indices::Vector{<:MOI.VariableIndex})
     # We throw away name_to_constraint_index so we will rebuild VariableIndex
     # constraint names without v.
     model.name_to_constraint_index = nothing
+    # _require_update(model, model_change = true)
     _update_if_necessary(model, force = true)
     return
 end
@@ -1055,7 +1056,7 @@ function MOI.delete(model::Optimizer, v::MOI.VariableIndex)
     # We throw away name_to_constraint_index so we will rebuild VariableIndex
     # constraint names without v.
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _require_update(model, model_change = true)
     return
 end
 
@@ -1565,7 +1566,7 @@ function MOI.delete(
     end
     info.upper_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1680,7 +1681,7 @@ function MOI.delete(
     end
     info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1696,7 +1697,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1712,7 +1713,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1860,7 +1861,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1898,7 +1899,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -1946,7 +1947,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 
@@ -2000,7 +2001,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model)
+    _require_update(model, attribute_change = true)
     return
 end
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3715,6 +3715,7 @@ function MOI.set(
     c::MOI.ConstraintIndex{MOI.ScalarAffineFunction{Float64},S},
     bs::MOI.BasisStatusCode,
 ) where {S<:_SCALAR_SETS}
+    _update_if_necessary(model)
     row = _info(model, c).row
     valueP::Cint = (
         if bs == MOI.BASIC
@@ -3737,6 +3738,7 @@ function MOI.set(
     x::MOI.VariableIndex,
     bs::MOI.BasisStatusCode,
 )
+    _update_if_necessary(model)
     valueP = if bs == MOI.BASIC
         Cint(0)
     elseif bs == MOI.NONBASIC_AT_LOWER

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1565,7 +1565,7 @@ function MOI.delete(
     end
     info.upper_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1680,7 +1680,7 @@ function MOI.delete(
     end
     info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1696,7 +1696,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1712,7 +1712,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1860,7 +1860,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1898,7 +1898,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -1946,7 +1946,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 
@@ -2000,7 +2000,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force = true)
+    _update_if_necessary(model)
     return
 end
 

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -1017,8 +1017,7 @@ function MOI.delete(model::Optimizer, indices::Vector{<:MOI.VariableIndex})
     # We throw away name_to_constraint_index so we will rebuild VariableIndex
     # constraint names without v.
     model.name_to_constraint_index = nothing
-    _require_update(model)
-    _update_if_necessary(model)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1035,8 +1034,7 @@ function MOI.delete(model::Optimizer, v::MOI.VariableIndex)
     # We throw away name_to_constraint_index so we will rebuild VariableIndex
     # constraint names without v.
     model.name_to_constraint_index = nothing
-    _require_update(model)
-    _update_if_necessary(model)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -4373,7 +4371,7 @@ function MOI.set(
     _update_if_necessary(model)
     ret = GRBsetstrattrelement(model, "QCName", Cint(info.row - 1), name)
     _check_ret(model, ret)
-    # _require_update(model)
+    _require_update(model)
     info.name = name
     if model.name_to_constraint_index === nothing || isempty(name)
         return

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -513,6 +513,7 @@ function _require_update(
     attribute_change::Bool = false,
     model_change::Bool = false,
 )
+    @assert attribute_change || model_change
     if attribute_change
         model.attribute_change = true
     end

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -517,7 +517,7 @@ Calls `GRBupdatemodel`, but only if the `model.needs_update` flag is set or
 force is true. This is necessary before most `GRBget*` calls (exceptions include
 some ModelAttributes that require calling optimize beforehand e.g. `ObjVal`)
 """
-function _update_if_necessary(model::Optimizer; force::Bool=false)
+function _update_if_necessary(model::Optimizer; force::Bool = false)
     if model.needs_update || force
         sort!(model.columns_deleted_since_last_update)
         for var_info in values(model.variable_info)
@@ -1546,7 +1546,7 @@ function MOI.delete(
     end
     info.upper_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1661,7 +1661,7 @@ function MOI.delete(
     end
     info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1677,7 +1677,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1693,7 +1693,7 @@ function MOI.delete(
     info.bound = _NONE
     info.upper_bound_if_bounded = info.lower_bound_if_bounded = NaN
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1841,7 +1841,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1879,7 +1879,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1927,7 +1927,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -1981,7 +1981,7 @@ function MOI.delete(
     _check_ret(model, ret)
     info.type = GRB_CONTINUOUS
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2144,7 +2144,7 @@ function MOI.delete(
         return isempty(searchsorted(cs_values, pair.first))
     end
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2162,7 +2162,7 @@ function MOI.delete(
     end
     delete!(model.affine_constraint_info, c.value)
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2381,7 +2381,7 @@ function MOI.delete(
     end
     delete!(model.quadratic_constraint_info, c.value)
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2553,7 +2553,7 @@ function MOI.delete(
     end
     delete!(model.sos_constraint_info, c.value)
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2573,7 +2573,7 @@ function MOI.delete(
         return isempty(searchsorted(cs_values, pair.first))
     end
     model.name_to_constraint_index = nothing
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 
@@ -2656,7 +2656,7 @@ function _check_moi_callback_validity(model::Optimizer)
 end
 
 function MOI.optimize!(model::Optimizer)
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     # Initialize callbacks if necessary.
     has_null_callback = false
     if _check_moi_callback_validity(model)
@@ -4307,7 +4307,7 @@ function MOI.delete(
         tmp_lower_bound,
     )
     _check_ret(model, ret)
-    _update_if_necessary(model, force=true)
+    _update_if_necessary(model, force = true)
     return
 end
 


### PR DESCRIPTION
Motivated by the large performance difference in [Discourse: Problem with JuMP + Gurobi.jl](https://discourse.julialang.org/t/problem-with-jump-gurobi-jl/111505). 

The idea is to only call `GRBupdatemodel` before `GRBget*` only. I've tried to adhere to calling `_update_if_required` at the start of the function or at the end. Additionally, adding the `force` argument to this function avoids having to use `_require_update`.

Some tests are failing still:

- [x] `test_Buffered_deletion_test`, `test_modify_after_delete*` (indexing should also be updated with delete? This is not expected from our other APIs)
- [x] `test_linear_SOS1_integration`
- [x] `test_set_basis`. When setting + getting `[V|C]Basis` we need to update beforehand. Doing this on the `MOI.set/get` leads to a lot of warning messages and (potentially) performance issues.

Work for the update part of https://github.com/jump-dev/Gurobi.jl/issues/516