### PR TITLE
Rebuild package when Gurobi installation changes

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,7 @@ end
 
 function write_depsfile(path)
     open(DEPS_FILE, "w") do io
-        println(io, "const libgurobi = \"$(escape_string(path))\"")
+        println(io, "libgurobi = \"$(escape_string(path))\"")
         return
     end
     return


### PR DESCRIPTION
Right now, when you update your local installation of Gurobi after having built `Gurobi.jl`, you need to execute `build.jl` again in order to update the `libgurobi` constant. This can be automated by making `libgurobi` non-constant, checking if the library can be loaded, and (if needed) re-run `build.jl`.