### PR TITLE
Fix return type of SimplexIterations

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3240,7 +3240,7 @@ function MOI.get(model::Optimizer, attr::MOI.SolveTimeSec)
     return valueP[]
 end
 
-function MOI.get(model::Optimizer, attr::MOI.SimplexIterations)
+function MOI.get(model::Optimizer, attr::MOI.SimplexIterations)::Int64
     _throw_if_optimize_in_progress(model, attr)
     valueP = Ref{Cdouble}()
     ret = GRBgetdblattr(model, "IterCount", valueP)
@@ -3248,20 +3248,20 @@ function MOI.get(model::Optimizer, attr::MOI.SimplexIterations)
     return valueP[]
 end
 
-function MOI.get(model::Optimizer, attr::MOI.BarrierIterations)
+function MOI.get(model::Optimizer, attr::MOI.BarrierIterations)::Int64
     _throw_if_optimize_in_progress(model, attr)
     valueP = Ref{Cint}()
     ret = GRBgetintattr(model, "BarIterCount", valueP)
     _check_ret(model, ret)
-    return Int(valueP[])
+    return valueP[]
 end
 
-function MOI.get(model::Optimizer, attr::MOI.NodeCount)
+function MOI.get(model::Optimizer, attr::MOI.NodeCount)::Int64
     _throw_if_optimize_in_progress(model, attr)
     valueP = Ref{Cdouble}()
     ret = GRBgetdblattr(model, "NodeCount", valueP)
     _check_ret(model, ret)
-    return round(Int64, valueP[])
+    return valueP[]
 end
 
 function MOI.get(model::Optimizer, attr::MOI.RelativeGap)
@@ -3284,7 +3284,7 @@ function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     return valueP[]
 end
 
-function MOI.get(model::Optimizer, attr::MOI.ResultCount)
+function MOI.get(model::Optimizer, attr::MOI.ResultCount)::Int
     _throw_if_optimize_in_progress(model, attr)
     if model.has_infeasibility_cert || model.has_unbounded_ray
         return 1
@@ -3292,7 +3292,7 @@ function MOI.get(model::Optimizer, attr::MOI.ResultCount)
     valueP = Ref{Cint}()
     ret = GRBgetintattr(model, "SolCount", valueP)
     _check_ret(model, ret)
-    return Int(valueP[])
+    return valueP[]
 end
 
 function MOI.get(model::Optimizer, ::MOI.Silent)


### PR DESCRIPTION
```julia
julia> begin
           model = read_from_file("benchmark/stroemer.mps.gz")
           set_optimizer(model, Gurobi.Optimizer)
           set_silent(model)
           optimize!(model)
           solution_summary(model)
       end
* Solver : Gurobi

* Status
  Result count       : 1
  Termination status : OPTIMAL
  Message from the solver:
  "Model was solved to optimality (subject to tolerances), and an optimal solution is available."

* Candidate solution (result #1)
  Primal status      : FEASIBLE_POINT
  Dual status        : FEASIBLE_POINT
  Objective value    : 2.77048e+05
  Objective bound    : 2.77048e+05
  Dual objective value : 2.77048e+05

* Work counters
  Solve time (sec)   : 2.98400e-02
  Barrier iterations : 0
  Node count         : 0


julia> simplex_iterations(model)
ERROR: TypeError: in typeassert, expected Int64, got a value of type Float64
Stacktrace:
 [1] _get_model_attribute(model::MathOptInterface.Utilities.CachingOptimizer{…}, attr::MathOptInterface.SimplexIterations)
   @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/1fRdT/src/Utilities/cachingoptimizer.jl:865
 [2] get(model::MathOptInterface.Utilities.CachingOptimizer{…}, attr::MathOptInterface.SimplexIterations)
   @ MathOptInterface.Utilities ~/.julia/packages/MathOptInterface/1fRdT/src/Utilities/cachingoptimizer.jl:900
 [3] _moi_get_result(model::MathOptInterface.Utilities.CachingOptimizer{…}, args::MathOptInterface.SimplexIterations)
   @ JuMP ~/.julia/packages/JuMP/6RAQ9/src/optimizer_interface.jl:1053
 [4] get(model::Model, attr::MathOptInterface.SimplexIterations)
   @ JuMP ~/.julia/packages/JuMP/6RAQ9/src/optimizer_interface.jl:1073
 [5] simplex_iterations(model::Model)
   @ JuMP ~/.julia/packages/JuMP/6RAQ9/src/optimizer_interface.jl:927
 [6] top-level scope
   @ REPL[12]:1
Some type information was truncated. Use `show(err)` to see complete types.
```