### PR TITLE
Track nonlinear resultant vars outside of MOI

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -566,6 +566,12 @@ function _update_if_necessary(
                 var_info.column,
             )
         end
+        for nl_info in values(model.nl_constraint_info)
+            nl_info.resvar_index -= searchsortedlast(
+                model.columns_deleted_since_last_update,
+                nl_info.resvar_index,
+            )
+        end
         model.next_column -= length(model.columns_deleted_since_last_update)
         empty!(model.columns_deleted_since_last_update)
         ret = GRBupdatemodel(model)

--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -96,9 +96,9 @@ mutable struct _NLConstraintInfo
     # Storage for constraint names. Where possible, these are also stored in
     # the Gurobi model.
     name::String
-    resvar::MOI.VariableIndex
-    function _NLConstraintInfo(row::Int, set, resvar::MOI.VariableIndex)
-        return new(row, set, "", resvar)
+    resvar_index::Int
+    function _NLConstraintInfo(row::Int, set, resvar_index::Int)
+        return new(row, set, "", resvar_index)
     end
 end
 

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -589,6 +589,72 @@ function test_add_constrained_variables()
     return
 end
 
+function test_add_constrained_variable_greaterthan()
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    set = MOI.GreaterThan{Float64}(1.2)
+    vi, ci = MOI.add_constrained_variable(model, set)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    @test MOI.get(model, MOI.ListOfConstraintTypesPresent()) ==
+          [(MOI.VariableIndex, MOI.GreaterThan{Float64})]
+    @test MOI.get(model, MOI.ConstraintFunction(), ci) == vi
+    @test MOI.get(model, MOI.ConstraintSet(), ci) == set
+    # Force update and check correct bounds on the Gurobi model
+    MOI.optimize!(model)
+    valueP = Ref{Cdouble}()
+    ret = Gurobi.GRBgetdblattrelement(model, "LB", 0, valueP)
+    @test ret == 0
+    @test valueP[] == 1.2
+    ret = Gurobi.GRBgetdblattrelement(model, "UB", 0, valueP)
+    @test ret == 0
+    @test valueP[] >= -1e30
+    return
+end
+
+function test_add_constrained_variable_lessthan()
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    set = MOI.LessThan{Float64}(3.4)
+    vi, ci = MOI.add_constrained_variable(model, set)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    @test MOI.get(model, MOI.ListOfConstraintTypesPresent()) ==
+          [(MOI.VariableIndex, MOI.LessThan{Float64})]
+    @test MOI.get(model, MOI.ConstraintFunction(), ci) == vi
+    @test MOI.get(model, MOI.ConstraintSet(), ci) == set
+    # Force update and check correct bounds on the Gurobi model
+    MOI.optimize!(model)
+    valueP = Ref{Cdouble}()
+    ret = Gurobi.GRBgetdblattrelement(model, "LB", 0, valueP)
+    @test ret == 0
+    @test valueP[] <= -1e30
+    ret = Gurobi.GRBgetdblattrelement(model, "UB", 0, valueP)
+    @test ret == 0
+    @test valueP[] == 3.4
+    return
+end
+
+function test_add_constrained_variable_equalto()
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.Silent(), true)
+    set = MOI.EqualTo{Float64}(5.2)
+    vi, ci = MOI.add_constrained_variable(model, set)
+    @test MOI.get(model, MOI.NumberOfVariables()) == 1
+    @test MOI.get(model, MOI.ListOfConstraintTypesPresent()) ==
+          [(MOI.VariableIndex, MOI.EqualTo{Float64})]
+    @test MOI.get(model, MOI.ConstraintFunction(), ci) == vi
+    @test MOI.get(model, MOI.ConstraintSet(), ci) == set
+    # Force update and check correct bounds on the Gurobi model
+    MOI.optimize!(model)
+    valueP = Ref{Cdouble}()
+    ret = Gurobi.GRBgetdblattrelement(model, "LB", 0, valueP)
+    @test ret == 0
+    @test valueP[] == 5.2
+    ret = Gurobi.GRBgetdblattrelement(model, "UB", 0, valueP)
+    @test ret == 0
+    @test valueP[] == 5.2
+    return
+end
+
 function _is_binary(x; atol = 1e-6)
     return isapprox(x, 0; atol = atol) || isapprox(x, 1; atol = atol)
 end

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1363,6 +1363,9 @@ function test_ConstrName_too_long()
 end
 
 function test_delete_nonlinear_index()
+    if !Gurobi._supports_nonlinear()
+        return
+    end
     model = Gurobi.Optimizer(GRB_ENV)
     x1 = MOI.add_variable(model)
     x2 = MOI.add_variable(model)

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -1384,6 +1384,7 @@ function test_delete_nonlinear_index()
     # is correctly adjusted.
     MOI.delete(model, c1)
     MOI.delete(model, c2)
+    return
 end
 
 end  # TestMOIWrapper

--- a/test/MOI/MOI_wrapper.jl
+++ b/test/MOI/MOI_wrapper.jl
@@ -65,15 +65,14 @@ function test_runtests()
             "_RotatedSecondOrderCone_",
             "_GeometricMeanCone_",
             # Shaky tests
-            "vector_nonlinear",
-            "VectorNonlinearFunction",
-            # Tests should be skipped due to RequirementsUnmet, but aren't
-            r"^test_nonlinear_expression_hs071$",
-            r"^test_nonlinear_expression_hs071_epigraph$",
+            "_multiobjective_vector_nonlinear",
+            # Timeouts
             r"^test_nonlinear_expression_hs109$",
             r"^test_nonlinear_expression_hs110$",
+            # MOI.get(MOI.ObjectiveValue()) fails for NL objectives
             r"^test_nonlinear_expression_quartic$",
             r"^test_nonlinear_expression_overrides_objective$",
+            # Nonlinear duals not computed
             r"^test_nonlinear_duals$",
         ],
     )


### PR DESCRIPTION
Alternative to #587: instead of filtering out the NL resultant variables when querying through MOI, don't add these variables to MOI at all so they don't show up in model queries.

- On deletion of NL constraints, deleted resvar indices are tracked on the deleted list for the next update operation
- In `_update_if_necessary`, the same index tracking trick applied to each entry in model.variable_info is applied to NL constraints as well, so that their resvar indices are appropriately adjusted following deletion of another variable.