### PR TITLE
Change DualObjectiveValue to use Utilities.get_fallback

### DIFF
--- a/src/MOI_wrapper/MOI_wrapper.jl
+++ b/src/MOI_wrapper/MOI_wrapper.jl
@@ -3366,13 +3366,7 @@ end
 function MOI.get(model::Optimizer, attr::MOI.DualObjectiveValue)
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
-    if model.has_infeasibility_cert
-        return MOI.Utilities.get_fallback(model, attr, Float64)
-    end
-    valueP = Ref{Cdouble}()
-    ret = GRBgetdblattr(model, "ObjBound", valueP)
-    _check_ret(model, ret)
-    return valueP[]
+    return MOI.Utilities.get_fallback(model, attr, Float64)
 end
 
 function MOI.get(model::Optimizer, attr::MOI.ResultCount)::Int


### PR DESCRIPTION
@blegat: I'm not really sure what we originally intended here.

```julia
help?> MOI.DualObjectiveValue
  DualObjectiveValue(result_index::Int = 1)

  A model attribute for the value of the objective function of the dual problem for the result_indexth dual result.

  If the solver does not have a dual value for the objective because the result_index is beyond the available solutions (whose number is indicated by the ResultCount attribute), getting this attribute
  must throw a ResultIndexBoundsError. Otherwise, if the result is unavailable for another reason (for instance, only a primal solution is available), the result is undefined. Users should first check
  DualStatus before accessing the DualObjectiveValue attribute.

  See ResultCount for information on how the results are ordered.
```