### PR TITLE
Fix callback with MINLP and hidden variables

### DIFF
--- a/src/MOI_wrapper/MOI_callbacks.jl
+++ b/src/MOI_wrapper/MOI_callbacks.jl
@@ -108,10 +108,9 @@ Load the solution during a callback so that it can be accessed using
 `MOI.CallbackVariablePrimal`.
 """
 function load_callback_variable_primal(cb_data::CallbackData, cb_where::Cint)
-    resize!(
-        cb_data.model.callback_variable_primal,
-        length(cb_data.model.variable_info),
-    )
+    pInt = Ref{Cint}(0)
+    ret = GRBgetintattr(cb_data.model, "NumVars", pInt)
+    resize!(cb_data.model.callback_variable_primal, pInt[])
     if cb_where == GRB_CB_MIPNODE
         ret = GRBcbget(
             cb_data,

--- a/test/MOI/MOI_callbacks.jl
+++ b/test/MOI/MOI_callbacks.jl
@@ -624,7 +624,7 @@ function test_CallbackFunction_broadcast()
 end
 
 function test_Callback_MINLP()
-    if Gurobi._GUROBI_VERSION < v"11"
+    if Gurobi._GUROBI_VERSION < v"12"
         return
     end
     model = Gurobi.Optimizer(GRB_ENV)

--- a/test/MOI/MOI_callbacks.jl
+++ b/test/MOI/MOI_callbacks.jl
@@ -623,6 +623,63 @@ function test_CallbackFunction_broadcast()
     return
 end
 
+function test_Callback_MINLP()
+    if Gurobi._GUROBI_VERSION < v"11"
+        return
+    end
+    model = Gurobi.Optimizer(GRB_ENV)
+    MOI.set(model, MOI.RawOptimizerAttribute("OutputFlag"), 0)
+    MOI.set(model, MOI.RawOptimizerAttribute("Cuts"), 0)
+    MOI.set(model, MOI.RawOptimizerAttribute("Presolve"), 0)
+    MOI.set(model, MOI.RawOptimizerAttribute("PreCrush"), 0)
+    MOI.set(model, MOI.RawOptimizerAttribute("Heuristics"), 0)
+    y, _ = MOI.add_constrained_variable(model, MOI.Interval(0.0, 1.0))
+    MOI.add_constraint(
+        model,
+        MOI.ScalarNonlinearFunction(:exp, Any[y]),
+        MOI.EqualTo(exp(0.5)),
+    )
+    N = 30
+    x = MOI.add_variables(model, N)
+    MOI.add_constraints(model, x, MOI.ZeroOne())
+    MOI.set.(model, MOI.VariablePrimalStart(), x, 0.0)
+    Random.seed!(1)
+    item_weights, item_values = rand(N), rand(N)
+    MOI.add_constraint(
+        model,
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(item_weights, x), 0.0),
+        MOI.LessThan(10.0),
+    )
+    MOI.set(
+        model,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Float64}}(),
+        MOI.ScalarAffineFunction(MOI.ScalarAffineTerm.(item_values, x), 0.0),
+    )
+    MOI.set(model, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    solutions = Any[]
+    MOI.set(
+        model,
+        Gurobi.CallbackFunction(),
+        (cb_data, cb_where) -> begin
+            if cb_where == Gurobi.GRB_CB_MIPSOL
+                Gurobi.load_callback_variable_primal(cb_data, cb_where)
+                ret = (
+                    MOI.get.(model, MOI.CallbackVariablePrimal(cb_data), x),
+                    MOI.get(model, MOI.CallbackVariablePrimal(cb_data), y),
+                )
+                push!(solutions, ret)
+            end
+        end,
+    )
+    MOI.optimize!(model)
+    @test length(solutions) > 0
+    for (x_sol, y_sol) in solutions
+        @test item_weights' * x_sol <= 10.0 + 1e-4
+        @test isapprox(y_sol, 0.5; atol = 1e-4)
+    end
+    return
+end
+
 end  # module TestCallbacks
 
 TestCallbacks.runtests()


### PR DESCRIPTION
Fixes https://discourse.julialang.org/t/memory-corruption-error-in-julia-incorrect-checksum-for-freed-object-when-running-a-jump-gurobi-model/130522

Nonlinear expressions introduce "hidden" variables, so the vector we were allocating for the callback solution was not long enough, and we were overwriting our memory space.